### PR TITLE
no opt for checking fns

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1805,6 +1805,10 @@ fcontract-semantic=
 C++ Joined RejectNegative
 -fcontract-semantic=<level>:<semantic>	Specify the concrete semantics for level.
 
+fcontract-disable-optimized-checks
+C++ Var(flag_contract_disable_optimized_checks) Init(0)
+-fcontract-disable-optimized-checks	Disable optimisation of contract checks.
+
 fcoroutines
 C++ LTO Var(flag_coroutines)
 Enable C++ coroutines (experimental).

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1351,7 +1351,6 @@ build_contract_condition_function (tree fndecl, bool pre)
   /* Create and rename the unchecked function and give an internal name.  */
   tree fn = copy_fn_decl (fndecl);
   DECL_RESULT (fn) = NULL_TREE;
-  tree value_type = pre ? void_type_node : TREE_TYPE (TREE_TYPE (fn));
 
   /* Don't propagate declaration attributes to the checking function,
      including the original contracts.  */
@@ -1374,27 +1373,25 @@ build_contract_condition_function (tree fndecl, bool pre)
 	continue;
       }
       *last = build_tree_list (TREE_PURPOSE (arg_type), TREE_VALUE (arg_type));
-      last = &TREE_CHAIN (*last);
     }
 
-  if (pre || VOID_TYPE_P (value_type))
-    *last = void_list_node;
-  else
+  tree orig_fn_value_type = TREE_TYPE (TREE_TYPE (fn));
+  if (!pre && !VOID_TYPE_P (orig_fn_value_type))
     {
+      /* For post contracts that deal with a non-void function, append a
+	 parameter to pass the return value.  */
       tree name = get_identifier ("__r");
-      tree parm = build_lang_decl (PARM_DECL, name, value_type);
+      tree parm = build_lang_decl (PARM_DECL, name, orig_fn_value_type);
       DECL_CONTEXT (parm) = fn;
       DECL_ARTIFICIAL (parm) = true;
       DECL_ARGUMENTS (fn) = chainon (DECL_ARGUMENTS (fn), parm);
-
-      *last = build_tree_list (NULL_TREE, value_type);
-      TREE_CHAIN (*last) = void_list_node;
-
-      /* The handler is a void return.  */
-      value_type = void_type_node;
+      *last = build_tree_list (NULL_TREE, orig_fn_value_type);
+      last = &TREE_CHAIN (*last);
     }
+  *last = void_list_node;
+  /* The handlers are void fns.  */
+  TREE_TYPE (fn) = build_function_type (void_type_node, arg_types);
 
-  TREE_TYPE (fn) = build_function_type (value_type, arg_types);
   if (DECL_IOBJ_MEMBER_FUNCTION_P (fndecl))
     TREE_TYPE (fn) = build_method_type (class_type, TREE_TYPE (fn));
 

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1356,6 +1356,19 @@ build_contract_condition_function (tree fndecl, bool pre)
      including the original contracts.  */
   DECL_ATTRIBUTES (fn) = NULL_TREE;
 
+  /* If requested, disable optimisation of checking functions; this can, in
+     some cases, prevent UB from eliding the checks themselves.  */
+  if (flag_contract_disable_optimized_checks)
+    DECL_ATTRIBUTES (fn)
+      = tree_cons (get_identifier ("optimize"),
+		   build_tree_list (NULL_TREE, build_string (3, "-O0")),
+		   NULL_TREE);
+  /* Now parse and add any internal representation of these attrs to the
+     decl.  */
+  if (DECL_ATTRIBUTES (fn))
+    cplus_decl_attributes (&fn, DECL_ATTRIBUTES (fn), 0);
+
+  /* Handle the args list.  */
   tree arg_types = NULL_TREE;
   tree *last = &arg_types;
 
@@ -2123,6 +2136,12 @@ maybe_apply_function_contracts (tree fndecl)
 void
 finish_function_contracts (tree fndecl)
 {
+  /* If the guarded func is either already decided to be ill-formed or is
+     not yet complete return early.  */
+  if (fndecl == error_mark_node
+      || DECL_INITIAL (fndecl) == error_mark_node)
+    return;
+
   if (!handle_contracts_p (fndecl)
       || !outline_contracts_p (fndecl))
     return;
@@ -2145,7 +2164,7 @@ finish_function_contracts (tree fndecl)
   if (pre == error_mark_node || post == error_mark_node)
     return;
 
-  if (pre && DECL_INITIAL (fndecl) != error_mark_node)
+  if (pre)
     {
       DECL_PENDING_INLINE_P (pre) = false;
       start_preparsed_function (pre, DECL_ATTRIBUTES (pre), flags);
@@ -2155,17 +2174,15 @@ finish_function_contracts (tree fndecl)
       expand_or_defer_fn (finished_pre);
     }
 
-  if (post && DECL_INITIAL (fndecl) != error_mark_node)
+  if (post)
     {
       DECL_PENDING_INLINE_P (post) = false;
-      start_preparsed_function (post,
+     start_preparsed_function (post,
 				DECL_ATTRIBUTES (post),
 				flags);
       remap_and_emit_conditions (fndecl, post, POSTCONDITION_STMT);
-      if (!VOID_TYPE_P (TREE_TYPE (TREE_TYPE (post))))
-	finish_return_stmt (get_postcondition_result_parameter (fndecl));
-      else
-	finish_return_stmt (NULL_TREE);
+      gcc_checking_assert (VOID_TYPE_P (TREE_TYPE (TREE_TYPE (post))));
+      finish_return_stmt (NULL_TREE);
 
       tree finished_post = finish_function (false);
       expand_or_defer_fn (finished_post);


### PR DESCRIPTION
this adds code (ifdef'd out) that can add an optimise attribute to the outlined contract checking functions.  In principle, this should prevent other fns from being inlined and therefore prevent the compiler from exploiting potential UB in those.

