### PR TITLE
c++, contracts: Handle object returns in the virtual fn wrapper.

### DIFF
--- a/gcc/cp/call.cc
+++ b/gcc/cp/call.cc
@@ -5119,10 +5119,7 @@ build_new_function_call (tree fn, vec<tree, va_gc> **args,
       result = error_mark_node;
     }
   else
-    {
-      result = build_over_call (cand, LOOKUP_NORMAL, complain);
-      result = maybe_contract_wrap_new_method_call(cand->fn, result);
-    }
+    result = build_over_call (cand, LOOKUP_NORMAL, complain);
 
   if (flag_coroutines
       && result
@@ -5256,8 +5253,6 @@ build_operator_new_call (tree fnname, vec<tree, va_gc> **args,
 
    /* Build the CALL_EXPR.  */
    tree ret = build_over_call (cand, LOOKUP_NORMAL, complain);
-
-   ret =maybe_contract_wrap_new_method_call(cand->fn, ret);
 
    /* Set this flag for all callers of this function.  In addition to
       new-expressions, this is called for allocating coroutine state; treat
@@ -5430,8 +5425,6 @@ build_op_call (tree obj, vec<tree, va_gc> **args, tsubst_flags_t complain)
 	     which is operator() turns out to be a static member function,
 	     `a' is none-the-less evaluated.  */
 	  result = keep_unused_object_arg (result, obj, cand->fn);
-
-	  result = maybe_contract_wrap_new_method_call(cand->fn, result);
 
 	}
       else
@@ -7298,7 +7291,6 @@ build_new_op (const op_location_t &loc, enum tree_code code, int flags,
 				"arguments");
 		}
 	      result = build_over_call (cand, LOOKUP_NORMAL, ocomplain);
-	      result = maybe_contract_wrap_new_method_call(cand->fn, result);
 	    }
 
 	  if (trivial_fn_p (cand->fn) || DECL_IMMEDIATE_FUNCTION_P (cand->fn))
@@ -7661,7 +7653,6 @@ build_op_subscript (const op_location_t &loc, tree obj,
 	     which is operator[] turns out to be a static member function,
 	     `a' is none-the-less evaluated.  */
 	  result = keep_unused_object_arg (result, obj, cand->fn);
-	  result = maybe_contract_wrap_new_method_call(cand->fn, result);
 	}
       else
 	gcc_unreachable ();
@@ -8635,7 +8626,6 @@ convert_like_internal (conversion *convs, tree expr, tree fn, int argnum,
 	      TARGET_EXPR_LIST_INIT_P (expr) = true;
 	  }
 
-	expr = maybe_contract_wrap_new_method_call(cand->fn, expr);
 	return expr;
       }
     case ck_identity:
@@ -10597,6 +10587,7 @@ build_over_call (struct z_candidate *cand, int flags, tsubst_flags_t complain)
       && DECL_BUILT_IN_CLASS (fn) == BUILT_IN_NORMAL)
     maybe_warn_class_memaccess (input_location, fn, args);
 
+  tree orig_fn = fn;
   if (DECL_VINDEX (fn) && (flags & LOOKUP_NONVIRTUAL) == 0)
     {
       tree t;
@@ -10630,7 +10621,7 @@ build_over_call (struct z_candidate *cand, int flags, tsubst_flags_t complain)
       ADDR_EXPR_DENOTES_CALL_P (fn) = true;
     }
 
-  tree call = build_cxx_call (fn, nargs, argarray, complain|decltype_flag);
+  tree call = build_cxx_call (fn, nargs, argarray, complain|decltype_flag, orig_fn);
   if (call == error_mark_node)
     return call;
   if (cand->flags & LOOKUP_LIST_INIT_CTOR)
@@ -11094,7 +11085,9 @@ build_cxx_call (tree fn, int nargs, tree *argarray,
   SET_EXPR_LOCATION (fn, loc);
 
   fndecl = get_callee_fndecl (fn);
-  if (!orig_fndecl)
+  if (!fndecl && orig_fndecl)
+    fndecl = orig_fndecl;
+  else if (!orig_fndecl)
     orig_fndecl = fndecl;
 
   /* Check that arguments to builtin functions match the expectations.  */
@@ -11135,8 +11128,11 @@ build_cxx_call (tree fn, int nargs, tree *argarray,
 	}
     }
 
+  /* When we have contracts enabled, and they are P2900-style then we might
+     wrap a virtual method call with caller-side checking.  */
+
   if (VOID_TYPE_P (TREE_TYPE (fn)))
-    return fn;
+    return maybe_contract_wrap_new_method_call (fndecl, fn);
 
   /* 5.2.2/11: If a function call is a prvalue of object type: if the
      function call is either the operand of a decltype-specifier or the
@@ -11148,6 +11144,7 @@ build_cxx_call (tree fn, int nargs, tree *argarray,
       fn = require_complete_type (fn, complain);
       if (fn == error_mark_node)
 	return error_mark_node;
+      fn = maybe_contract_wrap_new_method_call (fndecl, fn);
 
       if (MAYBE_CLASS_TYPE_P (TREE_TYPE (fn)))
 	{
@@ -11155,6 +11152,8 @@ build_cxx_call (tree fn, int nargs, tree *argarray,
 	  maybe_warn_parm_abi (TREE_TYPE (fn), loc);
 	}
     }
+  else
+    fn = maybe_contract_wrap_new_method_call (fndecl, fn);
   return convert_from_reference (fn);
 }
 
@@ -11889,8 +11888,6 @@ build_new_method_call (tree instance, tree fns, vec<tree, va_gc> **args,
 		   "operator delete(~X(f()))" (rather than generating
 		   "t = f(), ~X(t), operator delete (t)").  */
 		call = build_nop (void_type_node, call);
-
-	      call = maybe_contract_wrap_new_method_call(cand->fn, call);
 	    }
 	}
     }

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2419,12 +2419,12 @@ build_contract_wrapper_function (tree fndecl)
   /* no function body at present * */
   DECL_INITIAL (wrapdecl) = error_mark_node;
 
-
-  if (DECL_RESULT (fndecl))
-  {
-        DECL_RESULT (wrapdecl) = copy_decl (DECL_RESULT (fndecl));
-        DECL_CONTEXT (DECL_RESULT (wrapdecl)) = wrapdecl;
-  }
+  /* Build our result decl.  */
+  tree resdecl = build_decl (loc, RESULT_DECL, 0, wrapper_return_type);
+  DECL_CONTEXT (resdecl) = wrapdecl;
+  DECL_ARTIFICIAL (resdecl) = 1;
+  DECL_IGNORED_P (resdecl) = 1;
+  DECL_RESULT (wrapdecl) = resdecl;
 
   /* Copy the function parameters.  */
   tree last = DECL_ARGUMENTS (wrapdecl) = copy_decl (DECL_ARGUMENTS (fndecl));
@@ -2503,13 +2503,19 @@ set_contract_wrapper_function (tree decl, tree wrapper)
 tree
 maybe_contract_wrap_new_method_call (tree fndecl, tree call)
 {
+  /* We can be called from build_cxx_call without a known callee... */
+  if (!fndecl)
+    return call;
 
-  if (fndecl == error_mark_node) return fndecl;
+  if (fndecl == error_mark_node || call == error_mark_node)
+    return error_mark_node;
 
   /* We only need to wrap the function if it's a virtual function  */
-  if (!flag_contracts_nonattr || !handle_contracts_p (fndecl)
+  if (!flag_contracts_nonattr
+      || !handle_contracts_p (fndecl)
+      || !DECL_IOBJ_MEMBER_FUNCTION_P (fndecl)
       || !DECL_VIRTUAL_P (fndecl))
-      return call;
+    return call;
 
   bool do_pre = has_active_preconditions (fndecl);
   bool do_post = has_active_postconditions (fndecl);
@@ -2579,13 +2585,10 @@ bool define_contract_wrapper_func(const tree& fndecl, const tree& wrapdecl, void
 			    args->address ());
 
   if (!VOID_TYPE_P (return_type))
-    {
-      tree r = build_cplus_new(return_type, call, tf_warning_or_error);
-      finish_return_stmt (r);
-    }
-  else {
-      finish_return_stmt (NULL_TREE);
-  }
+    finish_return_stmt (call);
+  else
+    finish_return_stmt (NULL_TREE);
+
   finish_compound_stmt (compound_stmt);
   finish_function_body (body);
   expand_or_defer_fn (finish_function (/*inline_p=*/false));

--- a/gcc/testsuite/g++.dg/contracts/cpp26/virtual_func1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/virtual_func1.C
@@ -1,16 +1,23 @@
 // test that contracts on overriding functions are found correctly
 // { dg-do run }
 // { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr" }
+
 #include <cstdio>
+
+struct T {
+  int x;
+  T (int _x) : x(_x) {}
+  ~T () { x = -1; }
+};
 
 struct Base
 {
-  virtual int f(const int a) pre (a > 5);
+  virtual T f(const int a) pre (a > 5);
 };
 
-int Base::f(const int a)
+T Base::f(const int a)
 {
-  return a;
+  return T (a);
 }
 
 // inherits original
@@ -20,22 +27,21 @@ struct Child0 : Base
 
 struct Child1 : Base
 {
-  virtual int f(const int a) pre (a > 14){ return a + 10; }
+  virtual T f(const int a) pre (a > 14){ return T (a + 10); }
 };
 
 
 struct GChild1 : Child0
 {
-  virtual int f(const int a) post(a > 6) { return a + 100; };
+  virtual T f(const int a) post(a > 6) { return T (a + 100); };
 };
 
 struct GChild2 : Child1
 {
-  virtual int f(const int a) post(a > 30) { return a + 200; };
+  virtual T f(const int a) post(a > 30) { return T (a + 200); };
 };
 
-
-int fooBase(Base& b)
+T fooBase(Base& b)
 {
     return b.f(1);
 }
@@ -47,18 +53,18 @@ int main(int, char**)
   Child1 c1;
   GChild1 g1;
   GChild2 g2;
+  T q = b.f(3);     // a > 5
+  printf("Base: %d\n", q.x );
+  printf("Child0: %d\n", c0.f(3).x);  // a > 5
+  printf("Child1: %d\n", c1.f(7).x);  // a > 14
+  printf("GChild1: %d\n", g1.f(3).x);  // a > 6
+  printf("GChild2: %d\n", g2.f(7).x);  // a > 30
 
-  printf("Base: %d\n", b.f(3));     // a > 5
-  printf("Child0: %d\n", c0.f(3));  // a > 5
-  printf("Child1: %d\n", c1.f(7));  // a > 14
-  printf("GChild1: %d\n", g1.f(3));  // a > 6
-  printf("GChild2: %d\n", g2.f(7));  // a > 30
-
-  printf("fooBase(Base): %d\n", fooBase(b));     // a > 5
-  printf("fooBase(Child0): %d\n", fooBase(c0));     // a > 5
-  printf("fooBase(Child1): %d\n", fooBase(c1));     // a > 14
-  printf("fooBase(GChild1): %d\n", fooBase(g1));     // a > 6
-  printf("fooBase(GChild2): %d\n", fooBase(g2));     // a > 30
+  printf("fooBase(Base): %d\n", fooBase(b).x);     // a > 5
+  printf("fooBase(Child0): %d\n", fooBase(c0).x);     // a > 5
+  printf("fooBase(Child1): %d\n", fooBase(c1).x);     // a > 14
+  printf("fooBase(GChild1): %d\n", fooBase(g1).x);     // a > 6
+  printf("fooBase(GChild2): %d\n", fooBase(g2).x);     // a > 30
   return 0;
 }
 

--- a/gcc/testsuite/g++.dg/coroutines/virt-coro-00.C
+++ b/gcc/testsuite/g++.dg/coroutines/virt-coro-00.C
@@ -1,0 +1,121 @@
+// { dg-do run }
+// { dg-additional-options "-std=c++20 -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr" }
+#include <coroutine>
+
+#ifndef OUTPUT
+#  define PRINT(X)
+#  define PRINTF(...)
+#else
+#include <stdio.h>
+#  define PRINT(X) puts(X)
+#  define PRINTF(...) printf(__VA_ARGS__)
+#endif
+
+struct coro1 {
+  struct promise_type;
+  using handle_type = std::coroutine_handle<coro1::promise_type>;
+  handle_type handle;
+  coro1 () : handle(0) {}
+  coro1 (handle_type _handle)
+    : handle(_handle) {
+        PRINT("Created coro1 object from handle");
+  }
+  coro1 (const coro1 &) = delete; // no copying
+  coro1 (coro1 &&s) : handle(s.handle) {
+	s.handle = nullptr;
+	PRINT("coro1 mv ctor ");
+  }
+  coro1 &operator = (coro1 &&s) {
+	handle = s.handle;
+	s.handle = nullptr;
+	PRINT("coro1 op=  ");
+	return *this;
+  }
+  ~coro1() {
+        PRINT("Destroyed coro1");
+        if ( handle )
+          handle.destroy();
+  }
+
+  struct  suspend_always_prt {
+  bool await_ready() const noexcept { return false; }
+  void await_suspend(handle_type) const noexcept { PRINT ("susp-always-susp");}
+  void await_resume() const noexcept { PRINT ("susp-always-resume");}
+  ~suspend_always_prt() { PRINT ("susp-always-dtor"); }
+  };
+
+  struct promise_type {
+
+  promise_type() : vv(-1) {  PRINT ("Created Promise"); }
+  promise_type(int __x) : vv(__x) {  PRINTF ("Created Promise with %d\n",__x); }
+  ~promise_type() { PRINT ("Destroyed Promise"); }
+
+  auto get_return_object () {
+    PRINT ("get_return_object: handle from promise");
+    return handle_type::from_promise (*this);
+  }
+  auto initial_suspend () {
+    PRINT ("get initial_suspend (always)");
+    return suspend_always_prt{};
+  }
+  auto final_suspend () noexcept {
+    PRINT ("get final_suspend (always)");
+    return suspend_always_prt{};
+  }
+
+  void return_value (int v) {
+    PRINTF ("return_value (%d)\n", v);
+    vv = v;
+  }
+
+  void unhandled_exception() { PRINT ("** unhandled exception"); }
+
+  int get_value () { return vv; }
+  private:
+    int vv;
+  };
+};
+
+struct Base {
+  virtual struct coro1
+  f (const int v) noexcept [[pre: v == 41]] 
+  {
+    PRINT ("Base: about to return");
+    co_return v;
+   }
+};
+
+struct Derived : Base {
+  virtual struct coro1
+  f (const int v) noexcept [[pre: v == 6171]] override 
+  {
+    PRINT ("Derived: about to return");
+    co_return v;
+   }
+
+};
+
+int main ()
+{
+  PRINT ("main: create coro1");
+  Base b;
+  struct coro1 x = b.f (42);
+  x.handle.resume();
+  int y = x.handle.promise().get_value();
+  if ( y != 42 )
+    __builtin_abort ();
+
+  Derived d;
+  struct coro1 z = d.f (6174);
+  z.handle.resume();
+  y = z.handle.promise().get_value();
+  if ( y != 6174 )
+    __builtin_abort ();
+
+  struct coro1 c = d.Base::f (42);
+  c.handle.resume();
+  y = c.handle.promise().get_value();
+  if ( y != 42 )
+    __builtin_abort ();
+  return 0;
+}


### PR DESCRIPTION
'build_over_call' can return a TARGET_EXPR which the contracts wrapper machinery is not expecting.

1. move the wrapper insertion into build_cxx_call, so that we can do it before the TARGET_EXPRs are generated (which is easier than doing surgery on the generated ones).

2. Do not copy the original fn RESULT_DECL, but instead create a new one that has the correct type for the wrapper return (I am not sure, but suspect that the original fn return type can have been altered by copy elision).

3. The hack is this:
 - in build_cxx_call, we check the fndecl to see how to handle it.
 - this is done using 'get_callee_fndecl()' which does not understand how to look through virtual calls.. and therefore returns NULL_TREE which means we then fail to add the wrapper.
 - probably, the Right Fix is to make a cp_get_callee_fndecl() that does understand how to look through virtual calls..
 - but, instead since there is provision to pass in an 'orig_fndecl' and we actually know that in build_over_call, I added some logic to do that.

I added contract test case for the object return and a trivial coroutines one.

Not sure whether any of this is working properly with optimsation enabled (possibly because of the known D_A_O issue)

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
