### PR TITLE
removing DECL_ABSTRACT_ORIGIN on the wrapper

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2421,8 +2421,6 @@ copy_and_remap_contracts (tree dest, tree source, bool remap_post = true)
       CONTRACT_COMMENT (CONTRACT_STATEMENT (c)) =
 	copy_node (CONTRACT_COMMENT (CONTRACT_STATEMENT (c)));
 
-
-
       chainon (last, c);
       last = c;
       if (!contract_attrs)

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1557,8 +1557,7 @@ handle_contracts_p (tree decl1)
 {
   return (flag_contracts
 	  && !processing_template_decl
-	  && (DECL_ABSTRACT_ORIGIN (decl1) == NULL_TREE
-	      || DECL_IS_WRAPPER_FN_P(decl1))
+	  && (DECL_ABSTRACT_ORIGIN (decl1) == NULL_TREE)
 	  && contract_any_active_p (DECL_CONTRACTS (decl1)));
 }
 
@@ -2236,7 +2235,7 @@ finish_function_contracts (tree fndecl)
   if (pre == error_mark_node || post == error_mark_node)
     return;
 
-  if (pre)
+  if (pre && DECL_INITIAL (pre) == error_mark_node)
     {
       DECL_PENDING_INLINE_P (pre) = false;
       start_preparsed_function (pre, DECL_ATTRIBUTES (pre), flags);
@@ -2246,7 +2245,7 @@ finish_function_contracts (tree fndecl)
       expand_or_defer_fn (finished_pre);
     }
 
-  if (post)
+  if (post && DECL_INITIAL (post) == error_mark_node)
     {
       DECL_PENDING_INLINE_P (post) = false;
       start_preparsed_function (post,
@@ -2263,7 +2262,7 @@ finish_function_contracts (tree fndecl)
   /* Check if we need to update wrapper function contracts. */
   tree wrapdecl = get_contract_wrapper_function (fndecl);
   if (wrapdecl){
-      copy_and_remap_contracts (wrapdecl, fndecl);
+      copy_and_remap_contracts (wrapdecl, fndecl, true);
   }
 }
 
@@ -2389,28 +2388,40 @@ duplicate_contracts (tree newdecl, tree olddecl)
     }
 }
 
-/* Replace the any contract attributes on OVERRIDER with a copy where any
-   references to BASEFN's PARM_DECLs have been rewritten to the corresponding
-   PARM_DECL in OVERRIDER.  */
+/* Replace the any contract attributes on SOURCE with a copy where any
+   references to SOURCE's PARM_DECLs have been rewritten to the corresponding
+   PARM_DECL in DEST.  If remap_post is true, result identifier is
+   also re-mapped. C++20 version used this function to remap contracts on
+   virtual functions from base class to derived class. In such a case
+   postcondition identified wasn't remapped. Caller side wrapper functions
+   need to remap the result idnetifier. */
 
 void
-copy_and_remap_contracts (tree overrider, tree basefn)
+copy_and_remap_contracts (tree dest, tree source, bool remap_post = true)
 {
   tree last = NULL_TREE, contract_attrs = NULL_TREE;
-  for (tree a = DECL_CONTRACTS (basefn);
+  for (tree a = DECL_CONTRACTS (source);
       a != NULL_TREE;
       a = CONTRACT_CHAIN (a))
     {
       tree c = copy_node (a);
+      tree contract = CONTRACT_STATEMENT (c);
       TREE_VALUE (c) = build_tree_list (TREE_PURPOSE (TREE_VALUE (c)),
 					copy_node (CONTRACT_STATEMENT (c)));
 
-      tree src = basefn;
-      tree dst = overrider;
-      remap_contract (src, dst, CONTRACT_STATEMENT (c), /*duplicate_p=*/true);
+      remap_contract (source, dest, CONTRACT_STATEMENT (c), /*duplicate_p=*/true);
+
+      if ( remap_post && (TREE_CODE (CONTRACT_STATEMENT (c)) == POSTCONDITION_STMT))
+	{
+	  tree oldvar = POSTCONDITION_IDENTIFIER (CONTRACT_STATEMENT (c));
+	  if (oldvar)
+	      DECL_CONTEXT (oldvar) = dest;
+	}
 
       CONTRACT_COMMENT (CONTRACT_STATEMENT (c)) =
 	copy_node (CONTRACT_COMMENT (CONTRACT_STATEMENT (c)));
+
+
 
       chainon (last, c);
       last = c;
@@ -2418,7 +2429,7 @@ copy_and_remap_contracts (tree overrider, tree basefn)
 	contract_attrs = c;
     }
 
-  set_decl_contracts (overrider, contract_attrs);
+  set_decl_contracts (dest, contract_attrs);
 }
 
 /* Build a declaration for the contract wrapper of a caller FNDECL.  */
@@ -2431,7 +2442,7 @@ build_contract_wrapper_function (tree fndecl)
 
   /* Use mangled name so we can differentiate between different virtual
     functions of the same name. */
-  const char *name = IDENTIFIER_POINTER ((DECL_ASSEMBLER_NAME (fndecl)));
+  const char *name = IDENTIFIER_POINTER ((mangle_decl_string (fndecl)));
   name = ACONCAT ((name, ".contract_wrapper", NULL));
 
   location_t loc = DECL_SOURCE_LOCATION (fndecl);
@@ -2492,8 +2503,6 @@ build_contract_wrapper_function (tree fndecl)
    TODO : we can probably skip this step if function needs
    instantiating as it will be done as a part of instantiation. */
   copy_and_remap_contracts (wrapdecl, fndecl);
-
-  DECL_ABSTRACT_ORIGIN (wrapdecl) = fndecl;
 
   /* Make this function internal  */
   TREE_PUBLIC (wrapdecl) = false;

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -302,7 +302,7 @@ extern tree invalidate_contract			(tree);
 extern void update_late_contract		(tree, tree, tree);
 extern tree splice_out_contracts		(tree);
 extern bool all_attributes_are_contracts_p	(tree);
-extern void copy_and_remap_contracts		(tree, tree);
+extern void copy_and_remap_contracts		(tree, tree, bool);
 extern void start_function_contracts		(tree);
 extern void maybe_apply_function_contracts	(tree);
 extern void finish_function_contracts		(tree);

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -8478,6 +8478,7 @@ extern tree mangle_tls_wrapper_fn		(tree);
 extern bool decl_tls_wrapper_p			(tree);
 extern tree mangle_ref_init_variable		(tree);
 extern tree mangle_template_parm_object		(tree);
+extern tree mangle_decl_string                  (const tree);
 extern char *get_mangled_vtable_map_var_name    (tree);
 extern bool mangle_return_type_p		(tree);
 extern tree mangle_decomp			(tree, vec<tree> &);

--- a/gcc/cp/mangle.cc
+++ b/gcc/cp/mangle.cc
@@ -236,7 +236,6 @@ static int discriminator_for_string_literal (tree, tree);
 static void write_discriminator (const int);
 static void write_local_name (tree, const tree, const tree);
 static void dump_substitution_candidates (void);
-static tree mangle_decl_string (const tree);
 static void maybe_check_abi_tags (tree, tree = NULL_TREE, int = 10);
 static bool equal_abi_tags (tree, tree);
 
@@ -4396,7 +4395,7 @@ mangle_module_global_init (int module)
 
 /* Generate the mangled name of DECL.  */
 
-static tree
+tree
 mangle_decl_string (const tree decl)
 {
   tree result;

--- a/gcc/cp/search.cc
+++ b/gcc/cp/search.cc
@@ -2184,7 +2184,7 @@ check_final_overrider (tree overrider, tree basefn)
       {
 	/* We're inheriting basefn's contracts; create a copy of them but
 	   replace references to their parms to our parms.  */
-	copy_and_remap_contracts (overrider, basefn);
+	copy_and_remap_contracts (overrider, basefn, false);
       }
     else if (DECL_HAS_CONTRACTS_P (basefn) && DECL_HAS_CONTRACTS_P (overrider))
       {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/virtual_func.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/virtual_func.C
@@ -1,6 +1,6 @@
 // test that contracts on overriding functions are found correctly
-// { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr" }
+// { dg-do compile }
+// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -g3" }
 #include <cstdio>
 
 struct Base


### PR DESCRIPTION
not generating duplicate definitions of pre and post check fixing early mangling for checked function
fixing the context of postcondition identifier of a wrapper function

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
