### PR TITLE
removing unused DECL_IS_WRAPPER_FN_P macro

### DIFF
--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -278,11 +278,6 @@ enum contract_matching_context
 #define DECL_IS_POST_FN_P(NODE) \
   (DECL_ABSTRACT_ORIGIN (NODE) && DECL_POST_FN (DECL_ABSTRACT_ORIGIN (NODE)) == NODE)
 
-/* True iff the FUNCTION_DECL is the caller contract wrapper function
-  for a guarded function.  */
-#define DECL_IS_WRAPPER_FN_P(NODE) \
-  (DECL_ABSTRACT_ORIGIN (NODE) && DECL_WRAPPER_FN (DECL_ABSTRACT_ORIGIN (NODE)) == NODE)
-
 
 extern void remove_contract_attributes		(tree);
 extern void copy_contract_attributes		(tree, tree);


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
