### PR TITLE
c++, contracts: Fix reporting of 'observe' contracts.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1930,10 +1930,24 @@ get_evaluation_semantic(tree contract)
 {
   contract_semantic semantic = get_contract_semantic (contract);
 
-  if (checked_contract_p (semantic))
-    return CES_ENFORCE;
+  if (!flag_contracts_nonattr)
+    {
+      if (checked_contract_p (semantic))
+	return CES_ENFORCE;
+      return CES_OBSERVE;
+    }
 
-  return CES_OBSERVE;
+  switch (semantic)
+    {
+      default:
+	gcc_unreachable ();
+      case CCS_MAYBE:
+	return CES_OBSERVE;
+	break;
+      case CCS_NEVER:
+	return CES_ENFORCE;
+	break;
+    }
 }
 
 /* Build P2900R7 contract_violation layout compatible object. */

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
@@ -14,10 +14,10 @@ int main(int, char**)
   foo (1);
 }
 // { dg-output "contract violation in function foo at .*5: i > 3.*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 
 // { dg-output "contract violation in function foo at .*7: i > 5.*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: assert, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: assert, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 
 // { dg-output "contract violation in function foo at .*5: r > 4.*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
@@ -305,143 +305,143 @@ int main(int, char**)
 }
 
 // { dg-output {contract violation in function body<int> at .*:9: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-2(\n|\r\n|\r)} }
 // { dg-output {contract violation in function body<double> at .*:17: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-3(\n|\r\n|\r)} }
 // { dg-output {contract violation in function none<int> at .*:25: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function none<double> at .*:32: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-101(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg0<int> at .*:39: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-9(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg0<double> at .*:46: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {11(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg1<int> at .*:53: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function arg1<int> at .*:54: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-3(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg1<double> at .*:61: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function arg1<double> at .*:62: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {14(\n|\r\n|\r)} }
 // { dg-output {contract violation in function ret<int> at .*:69: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function ret<double> at .*:76: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {3(\n|\r\n|\r)} }
 // { dg-output {contract violation in function ret<double> at .*:76: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {3.300000(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g1<int> at .*:83: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g2<int> at .*:97: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g2<double> at .*:107: t < 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g2<char> at .*:114: t < 'c'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {100(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<double, double>::f at .*:124: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<double, double>::f at .*:125: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<int, int>::f at .*:139: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<int, int>::f at .*:140: s > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<int, double>::f at .*:147: t > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<int, double>::f at .*:148: s > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 full int double(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<char, char>::f at .*:124: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<char, char>::f at .*:125: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<int, char>::f at .*:139: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<int, char>::f at .*:140: s > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<int, int>::G4 at .*:173: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<int, int>::G4 at .*:174: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 general T S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<int, int>::G4 at .*:175: x > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 full double double(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<double, char>::G4 at .*:206: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<double, char>::G4 at .*:207: b > 'b'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 full double char(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<double, char>::G4 at .*:208: x > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<char, int>::G4 at .*:187: t > 'c'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<char, int>::G4 at .*:188: s > 3(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 partial char S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<char, int>::G4 at .*:189: x2 > 3(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<int> at .*:220: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<int> at .*:221: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<int> at .*:222: r > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<int, int>::f<double> at .*:220: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<double> at .*:221: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<double> at .*:222: r > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<char, int>::f<int> at .*:233: x > 'z'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<int> at .*:234: y > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<int> at .*:235: z > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 partial char S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<char, int>::f<double> at .*:233: x > 'z'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<double> at .*:234: y > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<double> at .*:235: z > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 partial char S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<double, double>::f<int> at .*:244: a > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<int> at .*:245: b > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<int> at .*:246: c > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 full double double, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<double, double>::f<double> at .*:244: a > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<double> at .*:245: b > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<double> at .*:246: c > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 full double double, f gen R(\n|\r\n|\r)} }


### PR DESCRIPTION
The c++2a implementation considers both terminated and continued contracts as 'checked' (which is, of course, true).  However it means that contract_checked_p() is not usable to differentiate enforce and observe.  For P2900 contracts we need to check the contract condition directly.

Fixed by checking the contract conditions directly.

(fixed up a few test cases that should report 'observe' because they have -fcontract-continuation-mode=on)
