### PR TITLE
Contracts nonattr add eval semantic opt

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1840,6 +1840,25 @@ fcontract-semantic=
 C++ Joined RejectNegative
 -fcontract-semantic=<level>:<semantic>	Specify the concrete semantics for level.
 
+Enum
+Name(p2900_semantic) Type(int)  UnknownError(unrecognized contract evaluation semantic %qs)
+
+EnumValue
+Enum(p2900_semantic) String(ignore) Value(1)
+
+EnumValue
+Enum(p2900_semantic) String(enforce) Value(3)
+
+EnumValue
+Enum(p2900_semantic) String(observe) Value(4)
+
+EnumValue
+Enum(p2900_semantic) String(quick_enforce) Value(5)
+
+fcontract-evaluation-semantic=
+C++ Joined RejectNegative Enum(p2900_semantic) Var(flag_contract_evaluation_semantic) Init (3)
+-fcontract-evaluation-semantic=[ignore,observe,enforce,quick_enforce]	Select the contract evaluation semantic (defaults to enforce).
+
 fcontract-disable-optimized-checks
 C++ Var(flag_contract_disable_optimized_checks) Init(0)
 -fcontract-disable-optimized-checks	Disable optimisation of contract checks.

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -146,6 +146,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "stor-layout.h"
 #include "intl.h"
 #include "cgraph.h"
+#include "opts.h"
 
 const int max_custom_roles = 32;
 static contract_role contract_build_roles[max_custom_roles] = {
@@ -761,8 +762,14 @@ grok_contract (tree attribute, tree mode, tree result, cp_expr condition,
   else
     contract = build4_loc (loc, code, type, mode, NULL_TREE, NULL_TREE, result);
 
-  /* Determine the concrete semantic.  */
-  set_contract_semantic (contract, compute_concrete_semantic (contract));
+  /* Determine the evaluation semantic:
+     First, apply the c++2a rules
+     FIXME: this is a convenience to avoid updating many tests.  */
+  contract_semantic semantic = compute_concrete_semantic (contract);
+  if (flag_contracts_nonattr
+      && OPTION_SET_P (flag_contract_evaluation_semantic))
+    semantic = static_cast<contract_semantic>(flag_contract_evaluation_semantic);
+  set_contract_semantic (contract, semantic);
 
   /* If the contract is deferred, don't do anything with the condition.  */
   if (TREE_CODE (condition) == DEFERRED_PARSE)
@@ -1881,12 +1888,21 @@ get_contract_role_name (tree contract)
 /* Build C++20 contract_violation layout compatible object. */
 
 static tree
-build_contract_violation_cpp20 (tree contract, contract_continuation cmode)
+build_contract_violation_cpp20 (tree contract)
 {
   expanded_location loc = expand_location (EXPR_LOCATION (contract));
   const char *function = fndecl_name (DECL_ORIGIN (current_function_decl));
   const char *level = get_contract_level_name (contract);
   const char *role = get_contract_role_name (contract);
+
+  /* Get the continuation mode.  */
+  contract_continuation cmode;
+  switch (get_contract_semantic (contract))
+    {
+    case CCS_NEVER: cmode = NEVER_CONTINUE; break;
+    case CCS_MAYBE: cmode = MAYBE_CONTINUE; break;
+    default: gcc_unreachable ();
+    }
 
   /* Must match the type layout in get_pseudo_contract_violation_type.  */
   tree ctor = build_constructor_va
@@ -1923,8 +1939,7 @@ get_contract_assertion_kind(tree contract)
   gcc_unreachable ();
 }
 
-/* Get constract_evaluation_semantic of the specified contract. Used when building
- P2900R7 contract_violation object. */
+/* Get contract_evaluation_semantic of the specified contract.  */
 static int
 get_evaluation_semantic(tree contract)
 {
@@ -1937,16 +1952,17 @@ get_evaluation_semantic(tree contract)
       return CES_OBSERVE;
     }
 
+  /* Used when building P2900R10 contract_violation object. Note that we do not
+     build such objects unless we are going to use them - so that we should not
+     get asked for 'ignore' or 'quick'.  */
   switch (semantic)
     {
       default:
 	gcc_unreachable ();
-      case CCS_MAYBE:
+      case CCS_OBSERVE:
 	return CES_OBSERVE;
-	break;
-      case CCS_NEVER:
+      case CCS_ENFORCE:
 	return CES_ENFORCE;
-	break;
     }
 }
 
@@ -1979,12 +1995,12 @@ build_contract_violation_P2900 (tree contract)
 /* Return a VAR_DECL to pass to handle_contract_violation.  */
 
 static tree
-build_contract_violation (tree contract, contract_continuation cmode)
+build_contract_violation (tree contract)
 {
   if (flag_contracts_nonattr)
     return build_contract_violation_P2900(contract);
 
-  return build_contract_violation_cpp20(contract, cmode);
+  return build_contract_violation_cpp20(contract);
 }
 
 /* Return handle_contract_violation(), declaring it if needed.  */
@@ -2054,10 +2070,9 @@ declare_handle_contract_violation ()
 /* Build the call to handle_contract_violation for CONTRACT.  */
 
 static void
-build_contract_handler_call (tree contract,
-			     contract_continuation cmode)
+build_contract_handler_call (tree contract)
 {
-  tree violation = build_contract_violation (contract, cmode);
+  tree violation = build_contract_violation (contract);
   tree violation_fn = declare_handle_contract_violation ();
   tree call = build_call_n (violation_fn, 1, build_address (violation));
   finish_expr_stmt (call);
@@ -2094,17 +2109,17 @@ build_contract_check (tree contract)
 				tf_warning_or_error);
   finish_if_stmt_cond (cond, if_stmt);
 
-  /* Get the continuation mode.  */
-  contract_continuation cmode;
-  switch (semantic)
+  /* Using the P2900 names here c++24 ENFORCE=NEVER, OBSERVE=MAYBE.  */
+  if (semantic == CCS_ENFORCE || semantic == CCS_OBSERVE)
+    build_contract_handler_call (contract);
+  if (semantic == CCS_QUICK)
     {
-    case CCS_NEVER: cmode = NEVER_CONTINUE; break;
-    case CCS_MAYBE: cmode = MAYBE_CONTINUE; break;
-    default: gcc_unreachable ();
+      tree fn = builtin_decl_explicit (BUILT_IN_ABORT);
+      releasing_vec vec;
+      finish_expr_stmt (finish_call_expr (fn, &vec, false, false,
+					  tf_warning_or_error));
     }
-
-  build_contract_handler_call (contract, cmode);
-  if (cmode == NEVER_CONTINUE)
+  else if (semantic == CCS_ENFORCE)
     finish_expr_stmt (build_call_a (terminate_fn, 0, nullptr));
 
   finish_then_clause (if_stmt);

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1930,10 +1930,24 @@ get_evaluation_semantic(tree contract)
 {
   contract_semantic semantic = get_contract_semantic (contract);
 
-  if (checked_contract_p (semantic))
-    return CES_ENFORCE;
+  if (!flag_contracts_nonattr)
+    {
+      if (checked_contract_p (semantic))
+	return CES_ENFORCE;
+      return CES_OBSERVE;
+    }
 
-  return CES_OBSERVE;
+  switch (semantic)
+    {
+      default:
+	gcc_unreachable ();
+      case CCS_MAYBE:
+	return CES_OBSERVE;
+	break;
+      case CCS_NEVER:
+	return CES_ENFORCE;
+	break;
+    }
 }
 
 /* Build P2900R7 contract_violation layout compatible object. */

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -36,13 +36,15 @@ enum contract_level
 
 enum contract_semantic
 {
-  CCS_INVALID,
-  CCS_IGNORE,
-  CCS_ASSUME,
-  CCS_NEVER,
-  CCS_MAYBE
+  CCS_INVALID = 0,
+  CCS_IGNORE = 1,
+  CCS_ASSUME = 2,
+  CCS_NEVER = 3,
+  CCS_ENFORCE = CCS_NEVER,
+  CCS_MAYBE = 4,
+  CCS_OBSERVE = CCS_MAYBE,
+  CCS_QUICK = 5
 };
-
 
 /* True if the contract is unchecked.  */
 
@@ -86,14 +88,15 @@ enum constract_assertion_kind {
   CAK_ASSERT = 3
 };
 
-enum constract_evaluation_semantic {
+enum contract_evaluation_semantic {
   CES_INVALID = 0,
-  CES_ENFORCE = 1 ,
-  CES_OBSERVE = 2
+  CES_ENFORCE = 1,
+  CES_OBSERVE = 2,
+  CES_QUICK = 3
 };
 
 enum constract_detection_mode {
-  CDM_PREDICATE_FALSE = 1 ,
+  CDM_PREDICATE_FALSE = 1,
   CDM_EVAL_EXCEPTION = 2
 };
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
@@ -14,10 +14,10 @@ int main(int, char**)
   foo (1);
 }
 // { dg-output "contract violation in function foo at .*5: i > 3.*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 
 // { dg-output "contract violation in function foo at .*7: i > 5.*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: assert, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: assert, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 
 // { dg-output "contract violation in function foo at .*5: r > 4.*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
@@ -305,143 +305,143 @@ int main(int, char**)
 }
 
 // { dg-output {contract violation in function body<int> at .*:9: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-2(\n|\r\n|\r)} }
 // { dg-output {contract violation in function body<double> at .*:17: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-3(\n|\r\n|\r)} }
 // { dg-output {contract violation in function none<int> at .*:25: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function none<double> at .*:32: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-101(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg0<int> at .*:39: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-9(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg0<double> at .*:46: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {11(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg1<int> at .*:53: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function arg1<int> at .*:54: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-3(\n|\r\n|\r)} }
 // { dg-output {contract violation in function arg1<double> at .*:61: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function arg1<double> at .*:62: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {14(\n|\r\n|\r)} }
 // { dg-output {contract violation in function ret<int> at .*:69: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function ret<double> at .*:76: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {3(\n|\r\n|\r)} }
 // { dg-output {contract violation in function ret<double> at .*:76: a > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {3.300000(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g1<int> at .*:83: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g2<int> at .*:97: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g2<double> at .*:107: t < 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
 // { dg-output {contract violation in function g2<char> at .*:114: t < 'c'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {100(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<double, double>::f at .*:124: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<double, double>::f at .*:125: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<int, int>::f at .*:139: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<int, int>::f at .*:140: s > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<int, double>::f at .*:147: t > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<int, double>::f at .*:148: s > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 full int double(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<char, char>::f at .*:124: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<char, char>::f at .*:125: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G3<int, char>::f at .*:139: t > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G3<int, char>::f at .*:140: s > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<int, int>::G4 at .*:173: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<int, int>::G4 at .*:174: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 general T S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<int, int>::G4 at .*:175: x > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 full double double(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<double, char>::G4 at .*:206: a > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<double, char>::G4 at .*:207: b > 'b'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 full double char(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<double, char>::G4 at .*:208: x > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<char, int>::G4 at .*:187: t > 'c'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G4<char, int>::G4 at .*:188: s > 3(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G4 partial char S(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G4<char, int>::G4 at .*:189: x2 > 3(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: post, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<int> at .*:220: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<int> at .*:221: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<int> at .*:222: r > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<int, int>::f<double> at .*:220: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<double> at .*:221: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<int, int>::f<double> at .*:222: r > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<char, int>::f<int> at .*:233: x > 'z'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<int> at .*:234: y > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<int> at .*:235: z > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 partial char S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<char, int>::f<double> at .*:233: x > 'z'(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<double> at .*:234: y > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<char, int>::f<double> at .*:235: z > 1(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 partial char S, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<double, double>::f<int> at .*:244: a > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<int> at .*:245: b > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<int> at .*:246: c > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 full double double, f gen R(\n|\r\n|\r)} }
 // { dg-output {contract violation in function G5<double, double>::f<double> at .*:244: a > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<double> at .*:245: b > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {contract violation in function G5<double, double>::f<double> at .*:246: c > 2(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: enforce, mode: predicate_false.(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false.(\n|\r\n|\r)" }
 // { dg-output {G5 full double double, f gen R(\n|\r\n|\r)} }


### PR DESCRIPTION
This is based on the fixes for observe semantics (but could probably be made stand-alone if needed).

In order to check all the pathways when we have contract check exception handling we really want `quick_enforce`.

It adds '-fcontract-evaluation-semantic=` with options `ignore`, `observe`, `enforce` and `quick_enforce`.  We then move a bit of code around to confine the c++2a cases locally and then add an implementation of `quick_enforce` that just calls abort() [we can fine-tune this later]

@NinaRanns (I pushed this as part of the const object branch)
