### PR TITLE
c++, contracts: Ensure deferred-parsed contracts are handled for lamb…

### DIFF
--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -12259,6 +12259,14 @@ cp_parser_lambda_body (cp_parser* parser, tree lambda_expr)
        removed the need for that.  */
     cp_parser_function_body (parser, false);
 
+    /* We need to parse deferred contract conditions before we try to call
+       finish_function (which will try to emit the contracts).  */
+    for (tree a = DECL_ATTRIBUTES (fco); a; a = TREE_CHAIN (a))
+      {
+	if (cxx_contract_attribute_p (a))
+	  cp_parser_late_contract_condition (parser, fco, a);
+      }
+
     finish_lambda_function (body);
   }
 

--- a/gcc/testsuite/g++.dg/contracts/pr117431.C
+++ b/gcc/testsuite/g++.dg/contracts/pr117431.C
@@ -1,0 +1,14 @@
+// { dg-do link }
+// { dg-options "-std=c++20 -fcontracts " }
+
+int foo (int x)
+{
+  auto f1 = [] (int y)
+    [[pre: y > 0]] { return y * y; };
+  return f1 (x);
+}
+
+int main ()
+{
+  return foo (-2);
+}


### PR DESCRIPTION
This is a fix for the upstream BZ (not yet posted) - this is pre-existing on the c++2a contracts branch, but I wanted to fix it to allow work on other issues.

@NinaRanns this is a fix for Issue #14 on your repo.
