### PR TITLE
adding std::observable to contract_assert and minor clean up

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1908,7 +1908,7 @@ Enum(p2900_semantic) String(quick_enforce) Value(5)
 
 fcontract-evaluation-semantic=
 C++ Joined RejectNegative Enum(p2900_semantic) Var(flag_contract_evaluation_semantic) Init (3)
--fcontract-evaluation-semantic=[ignore,observe,enforce,quick_enforce]	Select the contract evaluation semantic (defaults to enforce).
+-fcontract-evaluation-semantic=[ignore|observe|enforce|quick_enforce]	Select the contract evaluation semantic (defaults to enforce).
 
 fcontract-disable-optimized-checks
 C++ Var(flag_contract_disable_optimized_checks) Init(0)

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2256,6 +2256,18 @@ build_contract_check (tree contract)
   return cc_bind;
 }
 
+/* Insert a BUILT_IN_OBSERVABLE epoch marker.  */
+
+static void
+emit_builtin_observable ()
+{
+  tree fn = builtin_decl_explicit (BUILT_IN_OBSERVABLE);
+  releasing_vec vec;
+  fn = finish_call_expr (fn, &vec, false, false, tf_warning_or_error);
+  finish_expr_stmt (fn);
+
+}
+
 /* Add the contract statement CONTRACT to the current block if valid.  */
 
 static bool
@@ -2308,10 +2320,7 @@ void
 emit_assertion (tree attr)
 {
   /* Insert a std::observable () epoch marker.  */
-  tree fn = builtin_decl_explicit (BUILT_IN_OBSERVABLE);
-  releasing_vec vec;
-  fn = finish_call_expr (fn, &vec, false, false, tf_warning_or_error);
-  finish_expr_stmt (fn);
+  emit_builtin_observable();
 
   emit_contract_attr (attr);
 
@@ -2320,10 +2329,7 @@ emit_assertion (tree attr)
   if (semantic == CCS_OBSERVE)
     {
       /* Insert a std::observable () epoch marker.  */
-      tree fn = builtin_decl_explicit (BUILT_IN_OBSERVABLE);
-      releasing_vec vec;
-      fn = finish_call_expr (fn, &vec, false, false, tf_warning_or_error);
-      finish_expr_stmt (fn);
+      emit_builtin_observable();
     }
 }
 
@@ -2363,10 +2369,7 @@ remap_and_emit_conditions (tree fn, tree condfn, tree_code code)
 	  if (flag_contract_disable_check_epochs)
 	    continue;
 	  /* Insert a std::observable () epoch marker.  */
-	  tree fn = builtin_decl_explicit (BUILT_IN_OBSERVABLE);
-	  releasing_vec vec;
-	  fn = finish_call_expr (fn, &vec, false, false, tf_warning_or_error);
-	  finish_expr_stmt (fn);
+	  emit_builtin_observable();
 	}
     }
 }

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2307,7 +2307,24 @@ emit_contract_conditions (tree attrs, tree_code code)
 void
 emit_assertion (tree attr)
 {
+  /* Insert a std::observable () epoch marker.  */
+  tree fn = builtin_decl_explicit (BUILT_IN_OBSERVABLE);
+  releasing_vec vec;
+  fn = finish_call_expr (fn, &vec, false, false, tf_warning_or_error);
+  finish_expr_stmt (fn);
+
   emit_contract_attr (attr);
+
+  contract_semantic semantic = get_contract_semantic (CONTRACT_STATEMENT (attr));
+
+  if (semantic == CCS_OBSERVE)
+    {
+      /* Insert a std::observable () epoch marker.  */
+      tree fn = builtin_decl_explicit (BUILT_IN_OBSERVABLE);
+      releasing_vec vec;
+      fn = finish_call_expr (fn, &vec, false, false, tf_warning_or_error);
+      finish_expr_stmt (fn);
+    }
 }
 
 /* Emit statements for precondition attributes.  */

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-observable.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-observable.C
@@ -1,0 +1,27 @@
+//
+// { dg-do compile }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -O -fdump-tree-original -fdump-tree-optimized -Wno-return-type" }
+int f(int& i)
+{
+   i++;
+   return i;
+}
+
+int f2 (int x, const int *y)
+{
+    int b = x + *y;
+}
+
+int main(int ac, char *av[])
+{
+   int i = 3;
+   *av[0] = (char) f(i);
+   contract_assert (f2(i, &i) > 42);
+  return i;
+}
+// Check that
+// - observable checkpoint has been added to the contract_assert
+// - observable has been removed from the optimized tree
+
+// { dg-final { scan-tree-dump "__builtin_observable" "original" } }
+// { dg-final { scan-tree-dump "_2 = 4" "optimized" } }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-observable2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-observable2.C
@@ -1,0 +1,13 @@
+//
+// { dg-do compile }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fdump-tree-gimple " }
+
+
+int main(int ac, char *av[])
+{
+   int i = ac;
+   contract_assert (i == 3);
+  return i;
+}
+
+// { dg-final { scan-tree-dump "__builtin_observable.*handle_contract_violation.*__builtin_observable" "gimple" } }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception.C
@@ -1,0 +1,21 @@
+// { dg-do run }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-continuation-mode=on" }
+
+bool check(int i){
+  if (i > 10)
+    throw 3;
+
+  return true;
+}
+
+void f() pre(check(15)){}
+
+
+int main(int, char**)
+{
+
+  f();
+}
+
+// { dg-output "contract violation in function f at .*: check.15..*(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: evaluation_exception: threw an instance of .int., terminating: no.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/semantic-observe.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/semantic-observe.C
@@ -1,0 +1,21 @@
+// { dg-do run }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
+
+int f(int i, int j = 1) pre(i > 0) post(r: r < 5)
+{
+  contract_assert( j > 0);
+  return i;
+}
+
+
+int main(int, char**)
+{
+  f(5);
+  f(0,0);
+}
+// { dg-output "contract violation in function f at .*: r < 5.*(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false, terminating: no.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function f at .*: i > 0.*(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function f at .*: j > 0.*(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: assert, semantic: observe, mode: predicate_false, terminating: no.*(\n|\r\n|\r)" }


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
