### PR TITLE
github issue 17 fix - contract_assert not followed by a semicolon  causes a crash

### DIFF
--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -12964,6 +12964,8 @@ cp_parser_statement (cp_parser* parser, tree in_statement_expr,
 	      'contract_assert' */
 	      if (std_attrs == error_mark_node)
 		 std_attrs = NULL_TREE;
+	      else if (cp_lexer_next_token_is_not (parser->lexer, CPP_SEMICOLON))
+		cp_parser_error (parser, "expected semicolon");
 	    }
 	  else
 	    error_at (
@@ -13164,8 +13166,11 @@ cp_parser_statement (cp_parser* parser, tree in_statement_expr,
       if (cp_contract_assertion_p (std_attrs))
 	{
 	  /* Add the assertion as a statement in the current block.  */
-	  gcc_assert (!statement || statement == error_mark_node);
-	  emit_assertion (std_attrs);
+	  if (statement)
+	    error_at (statement_location,
+	   		"contract assertion on a non empty statement");
+	  else
+	    emit_assertion (std_attrs);
 	  std_attrs = NULL_TREE;
 	}
     }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert_err.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert_err.C
@@ -23,17 +23,26 @@ void f(contract_assert); // { dg-error "expected primary-expression before|decla
 struct contract_assert{}; // { dg-error "expected unqualified-id before|expected identifier" }
 void contract_assert(); // { dg-error "expected unqualified-id before" }
 
+void g(){};
 int main()
 {
-
     contract_assert(x==0); // { dg-error ".x. was not declared in this scope"}
     contract_assert int i = 0; // // { dg-error "expected primary-expression before|before .int." }
 
     i = 7;
     [[assert: i == 0]] contract_assert(x==0); // { dg-error "assertions must be followed by" }
 
+    int j = 4;
+
     contract_assert( x = 0); // { dg-error  "expected primary-expression before|expected .\\). before .=. token" }
 
     contract_assert( y == 0); // { dg-error ".y. was not declared in this scope" }
-	return 0;
+
+    contract_assert(true)
+    int k = 4; // { dg-error  "expected semicolon before .int." }
+
+    contract_assert(true) // { dg-error  "contract assertion on a non empty statement" }
+    g(); // { dg-error  "expected semicolon before .g." }
+
+    return 0;
 }


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
