### PR TITLE
c++, contracts do not require const keyword on template param

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2493,16 +2493,17 @@ maybe_reject_param_in_postcondition(tree decl)
 {
   if (flag_contracts_nonattr
       && processing_contract_postcondition
-      && !TREE_READONLY (decl) && !CP_TYPE_CONST_P (TREE_TYPE (decl))
+      && !dependent_type_p (TREE_TYPE (decl))
+      && !TREE_READONLY (decl)
+      && !CP_TYPE_CONST_P (TREE_TYPE (decl))
       && TREE_CODE (decl) == PARM_DECL
-      && !(REFERENCE_REF_P (decl) &&
-	   TREE_CODE (TREE_OPERAND (decl, 0)) == PARM_DECL))
-  {
+      && !(REFERENCE_REF_P (decl)
+	   && TREE_CODE (TREE_OPERAND (decl, 0)) == PARM_DECL))
+    {
       error_at (DECL_SOURCE_LOCATION (decl),
 		"a value parameter used in a postcondition must be const");
       return true;
-  }
-
+    }
   return false;
 }
 

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -21580,7 +21580,8 @@ tsubst_expr (tree t, tree args, tsubst_flags_t complain, tree in_decl)
 	      /* This can happen for a parameter name used later in a function
 		 declaration (such as in a late-specified return type).  Just
 		 make a dummy decl, since it's only used for its type.  */
-	      gcc_assert (cp_unevaluated_operand);
+	      gcc_assert (cp_unevaluated_operand
+			  || processing_contract_postcondition);
 	      r = tsubst_decl (t, args, complain);
 	      /* Give it the template pattern as its context; its true context
 		 hasn't been instantiated yet and this is good enough for

--- a/gcc/testsuite/g++.dg/contracts/cpp26-attr/contracts1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26-attr/contracts1.C
@@ -78,10 +78,10 @@ void postcond(int x) post(x >= 0); // { dg-error "a value parameter used in a po
 
 struct PostCond {
   void postcond(int x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
-  template<class T> void postcond2(T x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
+  template<class T> void postcond2(T x) post(x >= 0);
 };
 
-template <class T> void postcond3(T x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
+template <class T> void postcond3(T x) post(x >= 0);
 
 void postcond4(const int y, int x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts1.C
@@ -1,12 +1,5 @@
 // generic assert contract parsing checks
-//   check omitted, 'default', 'audit', and 'axiom' contract levels parse
-//   check that all concrete semantics parse
-//   check omitted, '%default' contract roles parse
-//   ensure that an invalid contract level 'invalid' errors
-//   ensure that a predicate referencing an undefined variable errors
-//   ensure that a missing colon after contract level errors
-//   ensure that an invalid contract role 'invalid' errors
-//   ensure that a missing colon after contract role errors
+
 // { dg-do compile }
 // { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr" }
 
@@ -27,41 +20,26 @@ int g2(int a) [[pre: f(a) > a ]]
 }
 
 int fun(int n)  pre (n > 0 );
-void fun2(int n)  pre  n > 0 ; // { dg-error  }
+void fun2(int n)  pre  n > 0 ; // { dg-error {expected '\(' before } }
+ // { dg-error {expected '\)' before ';' token} "" { target *-*-* } .-1 }
 void fun2(int n)  pre (: n > 0 ]]; // { dg-error  }
-int fun3(int n)  [[ pre : n > 0 ); // { dg-error "expected .]. before " }
+int fun3(int n)  [[ pre : n > 0 ); // { dg-error {expected '\]' before } }
 
 int main()
 {
   int x;
 
-  [[assert: x >= 0]];
-  [[assert default: x < 0]];
-  [[assert audit: x == 0]];
-  [[assert axiom: x == 1]];
+  contract_assert ( x >= 0 );
 
-  [[assert: x > 0 ? true : false]];
-  [[assert: x < 0 ? true : false]];
+  contract_assert ( x > 0 ? true : false );
+  contract_assert ( x < 0 ? true : false );
 
-  [[assert: x = 0]]; // { dg-error "expected .]. before .=. token" }
+  contract_assert ( x = 0 ); // { dg-error {expected '\)' before '=' token} }
+ // { dg-error {expected semicolon before '=' token} "" { target *-*-* } .-1 }
+ // { dg-error {expected primary-expression before '=' token} "" { target *-*-* } .-2 }
+ // { dg-error {contract assertion on a non empty statement} "" { target *-*-* } .-3 }
 
-  [[assert ignore: x >= 0]];
-  [[assert assume: x >= 0]];
-  [[assert check_never_continue: x >= 0]];
-  [[assert check_maybe_continue: x >= 0]];
-
-  [[assert %default: x >= 0]];
-  [[assert default %default: x < 0]];
-  [[assert audit %default: x == 0]];
-  [[assert axiom %default: x == 1]];
-
-  [[assert check_always_continue: x >= 0]]; // { dg-error "expected contract level" }
-  [[assert invalid: x == 0]]; // { dg-error "expected contract level" }
-  [[assert: y == 0]]; // { dg-error ".y. was not declared in this scope" }
-  [[assert default x == 0]]; // { dg-error "expected .:. before .x." }
-  [[assert %default x >= 0]]; // { dg-error "expected .:. before .x." }
-
-  [[assert %invalid: x >= 0]]; // TODO: optional warning?
+  contract_assert ( y == 0 ); // { dg-error ".y. was not declared in this scope" }
 
   return 0;
 }
@@ -78,10 +56,11 @@ void postcond(int x) post(x >= 0); // { dg-error "a value parameter used in a po
 
 struct PostCond {
   void postcond(int x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
-  template<class T> void postcond2(T x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
+  template<class T> void postcond2(T x) post(x >= 0);
 };
 
-template <class T> void postcond3(T x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
+template <class T> void
+postcond3(T x) post(x >= 0);
 
 void postcond4(const int y, int x) post(x >= 0); // { dg-error "a value parameter used in a postcondition must be const" }
 
@@ -106,3 +85,19 @@ void postcond6()
   b.i(6);
 }
 		  
+template<class T>
+void
+PostCond::postcond2(T x) post (x >= 0)  // { dg-error "a value parameter used in a postcondition must be const" }
+{ x; }
+
+template <class T>
+void
+postcond3(T x) post(x >= 0)  // { dg-error "a value parameter used in a postcondition must be const" }
+{ } 
+
+void postcond7()
+{
+  PostCond p;
+  p.postcond2 (2);
+  postcond3 (4);
+}


### PR DESCRIPTION
We agreed that a type could be const-qualified and therefore asking
for the keyword in addition was excessive.  So in the case of parms
that have templated types, defer complaint until instantiation.
    
The testcases are updated - including removing the attribute-style
contracts from the cxx26 edition (they are still present in  the
cpp26-attr set)
