### PR TITLE
Contracts nonattr NFC cleanups

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1852,7 +1852,7 @@ Enable the non-attribute syntax for contracts.
 
 fcontracts-nonattr-noconst
 C++ Var(flag_contracts_nonattr_noconst) Init(0)
-Disable the consitification of entities appearing in a contract condition.
+Disable the const-ification of entities appearing in a contract condition.
 
 fcontracts-nonattr-mutable-keyword
 C++ Var(flag_contracts_nonattr_mutable_keyword) Init(0)

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -12295,11 +12295,8 @@ cp_parser_lambda_body (cp_parser* parser, tree lambda_expr)
 
     /* We need to parse deferred contract conditions before we try to call
        finish_function (which will try to emit the contracts).  */
-    for (tree a = DECL_ATTRIBUTES (fco); a; a = TREE_CHAIN (a))
-      {
-	if (cxx_contract_attribute_p (a))
-	  cp_parser_late_contract_condition (parser, fco, a);
-      }
+    for (tree a = DECL_CONTRACTS (fco); a; a = CONTRACT_CHAIN (a))
+      cp_parser_late_contract_condition (parser, fco, a);
 
     finish_lambda_function (body);
   }
@@ -27606,11 +27603,8 @@ cp_parser_class_specifier (cp_parser* parser)
 	    parser->local_variables_forbidden_p |= THIS_FORBIDDEN;
 
 	  /* Now we can parse contract conditions.  */
-	  for (tree a = DECL_ATTRIBUTES (decl); a; a = TREE_CHAIN (a))
-	    {
-	      if (cxx_contract_attribute_p (a))
-		cp_parser_late_contract_condition (parser, decl, a);
-	    }
+	  for (tree a = DECL_CONTRACTS (decl); a; a = CONTRACT_CHAIN (a))
+	    cp_parser_late_contract_condition (parser, decl, a);
 
 	  /* Restore the state of local_variables_forbidden_p.  */
 	  parser->local_variables_forbidden_p = local_variables_forbidden_p;


### PR DESCRIPTION
This does not fix anything but is tidy-ups seen while working on other stuff (and might contribute to minimising fallout later)

We need to try and catch any cases where we're still referring to contracts via `DECL_ATTRIBUTES` and switch them to `DECL_CONTRACTS` - this is so that we can switch to disentangling p2900 contracts from the attributes, which is becoming more pressing - since they no longer have the same semantics as typical attrs.

Plus a typo fix