### PR TITLE
c++, contracts, Darwin: Fix local symbols for linker.

### DIFF
--- a/gcc/config/darwin.h
+++ b/gcc/config/darwin.h
@@ -996,6 +996,10 @@ extern GTY(()) section * darwin_sections[NUM_DARWIN_SECTIONS];
       sprintf (LABEL, "*%s%ld", "lASAN", (long)(NUM));\
     else if (strcmp ("LTRAMP", PREFIX) == 0)	\
       sprintf (LABEL, "*%s%ld", "lTRAMP", (long)(NUM));\
+    else if (strcmp ("Lcontract_violation", PREFIX) == 0)	\
+      sprintf (LABEL, "*%s%ld", "lcontract_violation", (long)(NUM));\
+    else if (strcmp ("Lsrc_loc_impl.", PREFIX) == 0)	\
+      sprintf (LABEL, "*%s%ld", "lsrc_loc_impl", (long)(NUM));\
     else						\
       sprintf (LABEL, "*%s%ld", PREFIX, (long)(NUM));	\
   } while (0)

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1999,7 +1999,7 @@ static tree
 build_contracts_source_location (location_t loc)
 {
   tree impl_ = contracts_tu_local_named_var
-    (loc, "Lsrc_loc_impl.",
+    (loc, "Lsrc_loc_impl",
      get_contracts_source_location_impl_type (), /*is_const*/true);
 
   DECL_INITIAL (impl_) = build_contracts_source_location_impl (loc);
@@ -2255,7 +2255,7 @@ build_contract_violation_P2900 (tree contract, bool is_const)
   TREE_STATIC (ctor) = true;
 
   tree viol_ = contracts_tu_local_named_var
-    (EXPR_LOCATION (contract), "Lcontract_violation.",
+    (EXPR_LOCATION (contract), "Lcontract_violation",
      get_pseudo_contract_violation_type (), /*is_const*/true);
 
   TREE_CONSTANT (viol_) = is_const;


### PR DESCRIPTION
Fixes a spurious fail for virtual function cases on Darwin, should be NOP on Linux

Darwin partitions objects into 'atoms' based on linker-visible symbols.  If these are not present, and weak and non-weak sections overlap we get spurious warnings.  We need the contract violation constants and the source locations to be visible.

In addition, this fixes those symbols such that we do not unconditionally emit periods into the names (some assemblers do not accept this).

TODO: fix other cases at some stage.

