### PR TITLE
c++, contracts: Fix debug and optimisation.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1559,7 +1559,7 @@ build_contract_condition_function (tree fndecl, bool pre)
 
   DECL_NAME (fn) = copy_node (DECL_NAME (fn));
   DECL_INITIAL (fn) = error_mark_node;
-  DECL_ABSTRACT_ORIGIN (fn) = fndecl;
+  CONTRACT_HELPER (fn) = pre ? ldf_contract_pre : ldf_contract_post;
 
   IDENTIFIER_VIRTUAL_P (DECL_NAME (fn)) = false;
   DECL_VIRTUAL_P (fn) = false;
@@ -1662,7 +1662,7 @@ handle_contracts_p (tree fndecl)
 {
   return (flag_contracts
 	  && !processing_template_decl
-	  && (DECL_ABSTRACT_ORIGIN (fndecl) == NULL_TREE)
+	  && (CONTRACT_HELPER (fndecl) == ldf_contract_none)
 	  && contract_any_active_p (DECL_CONTRACTS (fndecl)));
 }
 

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -311,12 +311,13 @@ enum contract_matching_context
 
 /* True iff the FUNCTION_DECL is the pre function for a guarded function.  */
 #define DECL_IS_PRE_FN_P(NODE) \
-  (DECL_ABSTRACT_ORIGIN (NODE) && DECL_PRE_FN (DECL_ABSTRACT_ORIGIN (NODE)) == NODE)
+  (DECL_DECLARES_FUNCTION_P (NODE) && DECL_LANG_SPECIFIC (NODE) && \
+   CONTRACT_HELPER (NODE) == ldf_contract_pre)
 
 /* True iff the FUNCTION_DECL is the post function for a guarded function.  */
 #define DECL_IS_POST_FN_P(NODE) \
-  (DECL_ABSTRACT_ORIGIN (NODE) && DECL_POST_FN (DECL_ABSTRACT_ORIGIN (NODE)) == NODE)
-
+  (DECL_DECLARES_FUNCTION_P (NODE) && DECL_LANG_SPECIFIC (NODE) && \
+   CONTRACT_HELPER (NODE) == ldf_contract_post)
 
 extern void remove_contract_attributes		(tree);
 extern void copy_contract_attributes		(tree, tree);

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -3015,6 +3015,13 @@ struct GTY(()) lang_decl_min {
   tree access;
 };
 
+enum lang_contract_helper
+{
+  ldf_contract_none = 0,
+  ldf_contract_pre,
+  ldf_contract_post
+};
+
 /* Additional DECL_LANG_SPECIFIC information for functions.  */
 
 struct GTY(()) lang_decl_fn {
@@ -3045,8 +3052,9 @@ struct GTY(()) lang_decl_fn {
 
   unsigned xobj_func : 1;
   unsigned contract_wrapper : 1;
+  ENUM_BITFIELD(lang_contract_helper) contract_helper : 2;
 
-  unsigned spare : 6;
+  unsigned spare : 4;
 
   /* 32-bits padding on 64-bit host.  */
 
@@ -3193,6 +3201,9 @@ struct GTY(()) lang_decl {
   (&DECL_LANG_SPECIFIC (NODE)->u.decomp)
 
 #endif /* ENABLE_TREE_CHECKING */
+
+#define CONTRACT_HELPER(NODE) \
+ (LANG_DECL_FN_CHECK (NODE)->contract_helper)
 
 /* For a FUNCTION_DECL or a VAR_DECL, the language linkage for the
    declaration.  Some entities (like a member function in a local

--- a/gcc/cp/mangle.cc
+++ b/gcc/cp/mangle.cc
@@ -822,9 +822,9 @@ write_mangled_name (const tree decl, bool top_level)
   /* If this is the pre/post function for a guarded function, append
      .pre/post, like something from create_virtual_clone.  */
   if (DECL_IS_PRE_FN_P (decl))
-    write_string (".pre");
+    write_string (JOIN_STR "pre");
   else if (DECL_IS_POST_FN_P (decl))
-    write_string (".post");
+    write_string (JOIN_STR "post");
 
   /* If this is a coroutine helper, then append an appropriate string to
      identify which.  */

--- a/gcc/testsuite/g++.dg/contracts/cpp26/debug-and-opt.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/debug-and-opt.C
@@ -1,0 +1,15 @@
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
+// { dg-additional-options "-O -g" }
+
+// Check that we do not ICE with debug + optimisation.
+
+int foo (const int i)
+  pre (i > 3)
+{
+  return i;
+}
+
+int main()
+{
+  foo (1);
+}


### PR DESCRIPTION
This fixes Issue #18 in @NinaRanns repo.

The use of DECL_ABSTRACT_ORIGIN to communicate to the mangler that functions are outlined pre and post was interacting badly with debug and opt.

Fixed by using a separate mechanism to do this.
