### PR TITLE
c++, contracts: Ensure we remove contracts before LTO streaming.

### DIFF
--- a/gcc/cp/tree.cc
+++ b/gcc/cp/tree.cc
@@ -36,6 +36,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "attribs.h"
 #include "flags.h"
 #include "selftest.h"
+#include "contracts.h"
 
 static tree bot_manip (tree *, int *, void *);
 static tree bot_replace (tree *, int *, void *);
@@ -6354,6 +6355,10 @@ cp_free_lang_data (tree t)
       DECL_EXTERNAL (t) = 1;
       TREE_STATIC (t) = 0;
     }
+
+  if (TREE_CODE (t) == FUNCTION_DECL)
+    remove_contract_attributes (t);
+
   if (TREE_CODE (t) == NAMESPACE_DECL)
     /* We do not need the leftover chaining of namespaces from the
        binding level.  */


### PR DESCRIPTION
This is another upstream bug, but not a regression - so .. just here for now.  Tested with ''-O2 -g -flto" on the contracts testsuite - two of our new tests are known fails with optimisation enabled and not affected by the LTO changes.

----

LTO does not (and should not) understand Front End trees .. but we were leaking them via the FUNCTION_DECL attributes.  Once we have finished code-gen they are done with.

Remove contracts in cp_free_lang_data, which is called right before the LTO stream out.

