### PR TITLE
Darwin: Update handling of long constant names.

### DIFF
--- a/gcc/config/darwin.h
+++ b/gcc/config/darwin.h
@@ -996,9 +996,11 @@ extern GTY(()) section * darwin_sections[NUM_DARWIN_SECTIONS];
       sprintf (LABEL, "*%s%ld", "lASAN", (long)(NUM));\
     else if (strcmp ("LTRAMP", PREFIX) == 0)	\
       sprintf (LABEL, "*%s%ld", "lTRAMP", (long)(NUM));\
-    else if (strcmp ("Lcontract_violation", PREFIX) == 0)	\
+    else if (strlen (PREFIX) == 19 \
+	     && strcmp ("Lcontract_violation", PREFIX) == 0)	\
       sprintf (LABEL, "*%s%ld", "lcontract_violation", (long)(NUM));\
-    else if (strcmp ("Lsrc_loc_impl.", PREFIX) == 0)	\
+    else if (strlen (PREFIX) == 13 \
+	     && strcmp ("Lsrc_loc_impl", PREFIX) == 0)	\
       sprintf (LABEL, "*%s%ld", "lsrc_loc_impl", (long)(NUM));\
     else						\
       sprintf (LABEL, "*%s%ld", PREFIX, (long)(NUM));	\


### PR DESCRIPTION
The long(er) names we are using for contracts constants (e.g. Lcontract_violation) is triggering a warning where the prefix to ASM_GENERATE_INTERNAL_LABEL is shorter than our literal; that warning becomes an error after stage1 and so needs to be fixed to allow bootstrap on Darwin.

This needs to be fixed more generally for Darwin upstream but the patch here is sufficient for the contracts branch and stage 4.

