### PR TITLE
Contracts nonattr location improvements

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -847,7 +847,7 @@ finish_contract_attribute (tree identifier, tree contract)
    if any.  */
 
 void
-update_late_contract (tree contract, tree result, tree condition)
+update_late_contract (tree contract, tree result, cp_expr condition)
 {
   if (TREE_CODE (contract) == POSTCONDITION_STMT)
     POSTCONDITION_IDENTIFIER (contract) = result;

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2849,17 +2849,24 @@ start_function_contracts (tree fndecl)
       if (POSTCONDITION_P (CONTRACT_STATEMENT (ca)))
 	if (tree id = POSTCONDITION_IDENTIFIER (CONTRACT_STATEMENT (ca)))
 	  {
+	    tree r_name = tree_strip_any_location_wrapper (id);
 	    if (TREE_CODE (id) == PARM_DECL)
-	      id = DECL_NAME (id);
-	    gcc_checking_assert (id && TREE_CODE (id) == IDENTIFIER_NODE);
-	    tree seen = lookup_name (id);
+	      r_name = DECL_NAME (id);
+	    gcc_checking_assert (r_name && TREE_CODE (r_name) == IDENTIFIER_NODE);
+	    tree seen = lookup_name (r_name);
 	    if (seen
 		&& TREE_CODE (seen) == PARM_DECL
 		&& DECL_CONTEXT (seen)
 		&& DECL_CONTEXT (seen) == fndecl)
 	      {
 		auto_diagnostic_group d;
-		error_at (EXPR_LOCATION (CONTRACT_STATEMENT (ca)),
+		location_t id_l = location_wrapper_p (id)
+				  ? EXPR_LOCATION (id)
+				  : DECL_SOURCE_LOCATION (id);
+		location_t co_l = EXPR_LOCATION (CONTRACT_STATEMENT (ca));
+		if (id_l != UNKNOWN_LOCATION)
+		  co_l = make_location (id_l, get_start (co_l), get_finish (co_l));
+		error_at (co_l,
 			  "contract postcondition result names must not shadow"
 			  " function parameters");
 		inform (DECL_SOURCE_LOCATION (seen),

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2691,18 +2691,26 @@ remap_and_emit_conditions (tree fn, tree condfn, tree_code code)
 tree
 finish_contract_condition (cp_expr condition)
 {
+  if (!condition || error_operand_p (condition))
+    return condition;
+
   /* Ensure we have the condition location saved in case we later need to
      emit a conversion error during template instantiation and wouldn't
-     otherwise have it.  */
-  if (!CAN_HAVE_LOCATION_P (condition) || EXCEPTIONAL_CLASS_P (condition))
+     otherwise have it.  This differs from maybe_wrap_with_location in that
+     it allows wrappers on EXCEPTIONAL_CLASS_P which includes CONSTRUCTORs.  */
+  if (!CAN_HAVE_LOCATION_P (condition)
+      && condition.get_location () != UNKNOWN_LOCATION)
     {
-      condition = build1_loc (condition.get_location (), VIEW_CONVERT_EXPR,
+      tree_code code
+	= (((CONSTANT_CLASS_P (condition) && TREE_CODE (condition) != STRING_CST)
+	    || (TREE_CODE (condition) == CONST_DECL && !TREE_STATIC (condition)))
+	  ? NON_LVALUE_EXPR : VIEW_CONVERT_EXPR);
+      condition = build1_loc (condition.get_location (), code,
 			      TREE_TYPE (condition), condition);
       EXPR_LOCATION_WRAPPER_P (condition) = true;
     }
 
-  if (condition == error_mark_node
-      || type_dependent_expression_p (condition))
+  if (type_dependent_expression_p (condition))
     return condition;
 
   return condition_conversion (condition);

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -334,7 +334,6 @@ extern void defer_guarded_contract_match	(tree, tree, tree);
 extern bool diagnose_misapplied_contracts	(tree);
 extern tree finish_contract_attribute		(tree, tree);
 extern tree invalidate_contract			(tree);
-extern void update_late_contract		(tree, tree, tree);
 extern tree splice_out_contracts		(tree);
 extern bool all_attributes_are_contracts_p	(tree);
 extern void copy_and_remap_contracts		(tree, tree, bool, bool);

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -8916,6 +8916,7 @@ extern tree make_postcondition_variable		(cp_expr);
 extern tree make_postcondition_variable		(cp_expr, tree);
 extern tree grok_contract			(tree, tree, tree, cp_expr, location_t);
 extern tree finish_contract_condition		(cp_expr);
+extern void update_late_contract		(tree, tree, cp_expr);
 extern tree constify_contract_access            (tree);
 extern bool maybe_reject_param_in_postcondition (tree);
 

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -31490,6 +31490,8 @@ cp_parser_contract_attribute_spec (cp_parser *parser, tree attribute,
 						   /*consume_paren=*/false);
 
       cp_token *last = cp_lexer_peek_token (parser->lexer);
+      location_t end = last->location;
+      loc = make_location (loc, loc, end);
 
       if (!attr_mode)
 	  parens.require_close (parser);
@@ -31540,6 +31542,13 @@ cp_parser_contract_attribute_spec (cp_parser *parser, tree attribute,
 
       /* Revert (any) constification of the current class object.  */
       current_class_ref = current_class_ref_copy;
+
+      if (contract != error_mark_node)
+	{
+	  location_t end = cp_lexer_peek_token (parser->lexer)->location;
+	  loc = make_location (loc, loc, end);
+	  SET_EXPR_LOCATION (contract, loc);
+	}
 
 	/* For natural syntax, we eat the parens here. For the attribute
 	syntax, it will be done one level up, we just need to skip to it. */

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -31645,9 +31645,9 @@ void cp_parser_late_contract_condition (cp_parser *parser,
       result = make_postcondition_variable (identifier, type);
       ++processing_template_decl;
     }
-  condition = cp_parser_conditional_expression (parser);
+  cp_expr parsed_condition = cp_parser_conditional_expression (parser);
   /* Commit to changes.  */
-  update_late_contract (contract, result, condition);
+  update_late_contract (contract, result, parsed_condition);
   /* Leave our temporary scope for the postcondition result.  */
   if (identifier)
     --processing_template_decl;

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -31502,6 +31502,8 @@ cp_parser_contract_attribute_spec (cp_parser *parser, tree attribute,
       DEFPARSE_INSTANTIATIONS (condition) = NULL;
 
       /* And its corresponding contract.  */
+      if (identifier)
+	identifier.maybe_add_location_wrapper ();
       contract = grok_contract (attribute, mode, identifier, condition, loc);
     }
   else
@@ -31588,16 +31590,19 @@ void cp_parser_late_contract_condition (cp_parser *parser,
   if (TREE_CODE (condition) != DEFERRED_PARSE)
     return;
 
-  tree identifier = NULL_TREE;
+  tree r_ident = NULL_TREE;
   if (TREE_CODE (contract) == POSTCONDITION_STMT)
-    identifier = POSTCONDITION_IDENTIFIER (contract);
+    r_ident = POSTCONDITION_IDENTIFIER (contract);
 
   tree type = TREE_TYPE (TREE_TYPE (fn));
-  if (identifier)
+  location_t r_loc = UNKNOWN_LOCATION;
+  if (r_ident)
     {
-      /* TODO: Can we guarantee that the identifier has a location? */
-      location_t loc = cp_expr_location (contract);
-      if (!check_postcondition_result (fn, type, loc))
+      r_loc = EXPR_LOCATION (r_ident);
+      r_ident = tree_strip_any_location_wrapper (r_ident);
+      if (r_loc == UNKNOWN_LOCATION)
+	r_loc = cp_expr_location (contract);
+      if (!check_postcondition_result (fn, type, r_loc))
 	{
 	  invalidate_contract (contract);
 	  return;
@@ -31649,16 +31654,17 @@ void cp_parser_late_contract_condition (cp_parser *parser,
   should_constify_contract = should_constify;
   /* Build a fake variable for the result identifier.  */
   tree result = NULL_TREE;
-  if (identifier)
+  if (r_ident)
     {
-      result = make_postcondition_variable (identifier, type);
+      cp_expr result_id (r_ident, r_loc);
+      result = make_postcondition_variable (result_id, type);
       ++processing_template_decl;
     }
   cp_expr parsed_condition = cp_parser_conditional_expression (parser);
   /* Commit to changes.  */
   update_late_contract (contract, result, parsed_condition);
   /* Leave our temporary scope for the postcondition result.  */
-  if (identifier)
+  if (r_ident)
     --processing_template_decl;
   processing_postcondition = old_pc;
   should_constify_contract = old_const;

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -12057,11 +12057,19 @@ tsubst_contract (tree decl, tree t, tree args, tsubst_flags_t complain,
     /* Make the variable available for lookup.  */
     register_local_specialization (newvar, oldvar);
 
-  CONTRACT_CONDITION (r)
-      = tsubst_expr (CONTRACT_CONDITION (t), args, complain, in_decl);
+  /* Contract conditions have a wider application of location wrappers than
+     other trees which will not work with the generic handling in tsubst_expr,
+     remove the wrapper here...  */
+  location_t cond_l = EXPR_LOCATION (CONTRACT_CONDITION (t));
+  tree cond_t = tree_strip_any_location_wrapper (CONTRACT_CONDITION (t));
 
-  /* The condition is converted to bool.  */
-  CONTRACT_CONDITION (r) = finish_contract_condition (CONTRACT_CONDITION (r));
+  /* ... and substitute with the contained expression.  */
+  cond_t = tsubst_expr (cond_t, args, complain, in_decl);
+
+  /* Converted to bool, if possible, and then re-apply a location wrapper
+     when required.  */
+  cp_expr new_condition (cond_t, cond_l);
+  CONTRACT_CONDITION (r) = finish_contract_condition (new_condition);
 
   /* And the comment.  */
   /* TODO : this does not do anything at the moment. The CONTRACT_COMMENT is


### PR DESCRIPTION
Here some fixes and improvements for contracts locations.

A Fix

We were not necessarily properly associating a good location range with deferred parsed cases.

B Fix

1. upstream GCC does not have a space for location in all trees
2. upstream GCC does wrap some trees in a location wrapper to resolve 1)
3. however that does not extend to one group of trees which happens to include CONSTRUCTORs
4. the contracts implementation extends the upstream facility and _does_ add a wrapper to CONSTRUCTORs.
5. however, that wrapper is not expected and/or replaced by the tsubst code - leading to an issue we saw

The fix is to handle the contracts-specific wrappers separately in tsubst_contract.

C Improvement

This makes a range for the whole contract rather than the keyword alone (seems like the GH interface does not get the char kerning right .. but)

```c++
   pre ( i > 3 ) 
   ^~~~~~~~
```
instead of

```c++
  pre ( i > 3)
  ^~~
```

D Improvement

Pick up the location of declared post-condition vars so that we can point to it instead of the start of the contact.


