### PR TITLE
c++, contracts: Make sure we check const-ification is required on post.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2763,6 +2763,7 @@ maybe_reject_param_in_postcondition (tree decl)
   if (flag_contracts_nonattr
       && !TREE_READONLY (decl)
       && TREE_CODE (decl) == PARM_DECL
+      && should_constify_contract
       && processing_postcondition
       && !dependent_type_p (TREE_TYPE (decl))
       && !CP_TYPE_CONST_P (TREE_TYPE (decl))

--- a/gcc/testsuite/g++.dg/contracts/cpp26/postcondition-with-nonconst.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/postcondition-with-nonconst.C
@@ -1,0 +1,11 @@
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr -fcontracts-nonattr-noconst" }
+
+// This should compile without error.
+
+class X {
+
+static int calc ()
+  post (alignment: 0 == (alignment & (alignment-1)));
+
+};
+


### PR DESCRIPTION
lightly tested on x86_64.

------

We omitted to check the disabled condition when verifying postcondtions.

