### PR TITLE
constify globals and non type template parameters of reference type

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2742,12 +2742,13 @@ constify_contract_access(tree decl)
    * parameter of reference type
    */
   if (!TREE_READONLY (decl)
-      && ((VAR_P (decl) && decl_storage_duration (decl) == dk_auto)
+      && (VAR_P (decl)
 	  || (TREE_CODE (decl) == PARM_DECL)
 	  || (REFERENCE_REF_P (decl)
-	      && ((VAR_P (TREE_OPERAND (decl, 0))
-		   && decl_storage_duration(TREE_OPERAND (decl, 0)) == dk_auto)
-		  || (TREE_CODE (TREE_OPERAND (decl, 0)) == PARM_DECL)))))
+	      && (VAR_P (TREE_OPERAND (decl, 0))
+		  || (TREE_CODE (TREE_OPERAND (decl, 0)) == PARM_DECL)
+		  || (TREE_CODE (TREE_OPERAND (decl, 0))
+		      == TEMPLATE_PARM_INDEX)))))
   {
       decl = view_as_const (decl);
   }

--- a/gcc/cp/semantics.cc
+++ b/gcc/cp/semantics.cc
@@ -4720,6 +4720,7 @@ finish_id_expression_1 (tree id_expression,
 						   | TYPE_QUAL_CONST));
 	  r = build1 (VIEW_CONVERT_EXPR, ctype, r);
 	}
+
       r = convert_from_reference (r);
       if (integral_constant_expression_p
 	  && !dependent_type_p (TREE_TYPE (decl))
@@ -4731,6 +4732,11 @@ finish_id_expression_1 (tree id_expression,
 		   "integral or enumeration type", decl, TREE_TYPE (decl));
 	  *non_integral_constant_expression_p = true;
 	}
+
+      if (flag_contracts_nonattr && should_constify_contract
+	  && processing_contract_condition)
+	r = constify_contract_access(r);
+
       return r;
     }
   else if (TREE_CODE (decl) == UNBOUND_CLASS_TEMPLATE)

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification.C
@@ -18,12 +18,15 @@ static_assert (__cpp_contracts_roles >= 201906);
 int gi = 7;
 int &gri = gi;
 
+bool f(int&&){ return true;}
+int temporary(){ return 4;}
 
 void f1(int i) pre(i++); // { dg-error "increment of read-only location" }
 void f2(int &i) pre(i++); // { dg-error "increment of read-only location" }
 void f3(int *i) pre(i++); // { dg-error "increment of read-only location" }
 void f4(int *i) pre((*i)++); // ok, not deep const
-void f5(int *i) pre(gi++); //  ok, non automatic storage
+void f5(int *i) pre(gi++); // { dg-error "increment of read-only location" }
+void f6() pre(f(temporary())); // ok, lifetime started within pre condition
 
 // todo structured binding test
 // lambda tests
@@ -97,8 +100,8 @@ int main()
   contract_assert(ri++); // { dg-error "increment of read-only location" }
   ri = 6;
 
-  contract_assert(gi++); // ok, not automatic storage
-  contract_assert(gri++); // ok, not automatic storage
+  contract_assert(gi++); // { dg-error "increment of read-only location" }
+  contract_assert(gri++); // { dg-error "increment of read-only location" }
 
   int& rgi = gi;
   contract_assert(rgi++); // { dg-error "increment of read-only location" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification_const.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification_const.C
@@ -23,7 +23,7 @@ void f1(int i) pre const(i++); // { dg-error "increment of read-only location" }
 void f2(int &i) pre const(i++); // { dg-error "increment of read-only location" }
 void f3(int *i) pre const(i++); // { dg-error "increment of read-only location" }
 void f4(int *i) pre const((*i)++); // ok, not deep const
-void f5(int *i) pre const(gi++); //  ok, non automatic storage
+void f5(int *i) pre const(gi++); // { dg-error "increment of read-only location" }
 
 // todo structured binding test
 // lambda tests
@@ -97,8 +97,8 @@ int main()
   contract_assert const(ri++); // { dg-error "increment of read-only location" }
   ri = 6;
 
-  contract_assert const(gi++); // ok, not automatic storage
-  contract_assert const(gri++); // ok, not automatic storage
+  contract_assert const(gi++); // { dg-error "increment of read-only location" }
+  contract_assert const(gri++); // { dg-error "increment of read-only location" }
 
   int& rgi = gi;
   contract_assert const(rgi++); // { dg-error "increment of read-only location" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification_const_mutable.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification_const_mutable.C
@@ -23,10 +23,11 @@ void f1(int i) pre const(i++); // { dg-error "increment of read-only location" }
 void f2(int &i) pre const(i++); // { dg-error "increment of read-only location" }
 void f3(int *i) pre const(i++); // { dg-error "increment of read-only location" }
 void f4(int *i) pre const((*i)++); // ok, not deep const
-void f5(int *i) pre const(gi++); //  ok, non automatic storage
+void f5(int *i) pre const(gi++); // { dg-error "increment of read-only location" }
 void f6(int *i) pre const mutable(gi++); // { dg-error {cannot be both 'const' and 'mutable'} }
+// { dg-error {increment of read-only location} "" { target *-*-* } .-1 }
 void f7(int *i) pre const((*i)++) pre mutable((*i)++); // ok, not deep const
-void f8(int *i) pre const(gi++) pre mutable(gi++); //  ok, non automatic storage
+void f8(int *i) pre const(gi++) pre mutable(gi++); // { dg-error "increment of read-only location" }
 
 // todo structured binding test
 // lambda tests
@@ -81,7 +82,7 @@ void template_related_tests()
   perfect_forward(ci);
   perfect_forward((const int&&) ci);
   perfect_forward2(666);
-// { dg-error {increment of read-only location} "" { target *-*-* } 66 }
+// { dg-error {increment of read-only location} "" { target *-*-* } 67 }
   S2 s;
   const S2 cs;
   s.perfect_forward();
@@ -109,8 +110,8 @@ int main()
   contract_assert const(ri++); // { dg-error "increment of read-only location" }
   ri = 6;
 
-  contract_assert const(gi++); // ok, not automatic storage
-  contract_assert const(gri++); // ok, not automatic storage
+  contract_assert const(gi++); // { dg-error "increment of read-only location" }
+  contract_assert const(gri++); // { dg-error "increment of read-only location" }
 
   int& rgi = gi;
   contract_assert const(rgi++); // { dg-error "increment of read-only location" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification_mutable.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification_mutable.C
@@ -23,10 +23,11 @@ void f1(int i) pre(i++); // { dg-error "increment of read-only location" }
 void f2(int &i) pre(i++); // { dg-error "increment of read-only location" }
 void f3(int *i) pre(i++); // { dg-error "increment of read-only location" }
 void f4(int *i) pre((*i)++); // ok, not deep const
-void f5(int *i) pre(gi++); //  ok, non automatic storage
+void f5(int *i) pre(gi++); // { dg-error "increment of read-only location" }
 void f6(int i) pre mutable(i++);
 void f7(int &i) pre mutable(i++);
 void f8(int *i) pre mutable(i++);
+void f9(int *i) pre mutable(gi++);
 
 // todo structured binding test
 // lambda tests
@@ -114,8 +115,8 @@ int main()
   contract_assert mutable(ri++);
   ri = 6;
 
-  contract_assert(gi++); // ok, not automatic storage
-  contract_assert(gri++); // ok, not automatic storage
+  contract_assert(gi++); // { dg-error "increment of read-only location" }
+  contract_assert(gri++); // { dg-error "increment of read-only location" }
 
   int& rgi = gi;
   contract_assert(rgi++); // { dg-error "increment of read-only location" }


### PR DESCRIPTION
adding constification of globals and non type template parameters of reference type

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
