### PR TITLE
various fixes

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1474,6 +1474,11 @@ build_contract_condition_function (tree fndecl, bool pre)
      including the original contracts.  */
   DECL_ATTRIBUTES (fn) = NULL_TREE;
 
+  /* DECL_ASSEMBLER_NAME will be copied from FNDECL if it's already set. Unset
+     it so fn name later gets mangled according to the rules for pre and post
+     functions.  */
+  SET_DECL_ASSEMBLER_NAME (fn, NULL_TREE);
+
   /* If requested, disable optimisation of checking functions; this can, in
      some cases, prevent UB from eliding the checks themselves.  */
   if (flag_contract_disable_optimized_checks)
@@ -1939,8 +1944,6 @@ build_contract_wrapper_function (tree fndecl, bool is_cvh)
 
   /* Copy selected attributes from the original function.  */
   TREE_USED (wrapdecl) = TREE_USED (fndecl);
-  if (DECL_SECTION_NAME (fndecl))
-    set_decl_section_name (wrapdecl, fndecl);
 
   /* Copy any alignment that the FE added.  */
   if (DECL_ALIGN (fndecl))
@@ -3429,14 +3432,6 @@ maybe_contract_wrap_call (tree fndecl, tree call)
      client-side checks are enabled).  */
   if (!should_contract_wrap_call (do_pre, do_post, is_virtual))
     return call;
-
-  /* We should not have reached here with nothing to do.  */
-  /* We check postconditions on virtual function calls or if postcondition
-     checks are enabled for all clients.  */
-  gcc_checking_assert (do_pre
-		       || (do_post
-			   && ((flag_contract_nonattr_client_check > 1)
-			       || is_virtual)));
 
   /* Build the declaration of the wrapper, if we need to.  */
   tree wrapdecl = get_contract_wrapper_function (fndecl);

--- a/gcc/testsuite/g++.dg/contracts/cpp26/virtual-base.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/virtual-base.C
@@ -1,0 +1,24 @@
+// check that we do not a section type conflict with virtual bases or a duplicate symbol
+// { dg-do run }
+// { dg-options "-fcontracts -std=c++23 -fcontracts-nonattr" }
+
+int x = 9;
+struct Base
+{
+  virtual void f(){};
+};
+
+
+struct Child0 : virtual Base
+{
+  virtual void f() pre(x>2) {};
+};
+
+
+
+int main(int, char**)
+{
+  Base b0;
+  Child0 c0;
+  c0.f();
+}

--- a/gcc/testsuite/g++.dg/contracts/cpp26/virtual_func.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/virtual_func.C
@@ -1,6 +1,6 @@
 // test that contracts on overriding functions are found correctly
-// { dg-do compile }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -g3" }
+// { dg-do run }
+// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr" }
 #include <cstdio>
 
 struct Base
@@ -62,33 +62,33 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Base: 3(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Child0: 3(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "Child1: 17(\n|\r\n|\r)" }
 // { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 6.*(\n|\r\n|\r)" }
 // { dg-output "GChild1: 103(\n|\r\n|\r)" }
 // { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 30.*(\n|\r\n|\r)" }
 // { dg-output "GChild2: 207(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Base.: 1(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Child0.: 1(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Child1.: 11(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.GChild1.: 101(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .*contract_wrapper at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.GChild2.: 201(\n|\r\n|\r)" }


### PR DESCRIPTION
this commit contains:
- not copying a section name for contracts wrapper functions to avoid duplicate section names
- clearing assembler name for contracts check functions to avoid duplicate symbol names
- adding a test for the two issues above 
- removing an unnecessary assert. The condition is also checked in the call just before the assert. With time, we expect this condition to become more complex.
- changing a test from compile to run mode and fixing the expected result