### PR TITLE
addressing return value constness

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2724,10 +2724,14 @@ finish_contract_condition (cp_expr condition)
 
 tree view_as_const(tree decl)
 {
-  tree ctype = TREE_TYPE (decl);
-  ctype = cp_build_qualified_type (ctype, (cp_type_quals (ctype)
-						     | TYPE_QUAL_CONST));
-  decl = build1 (VIEW_CONVERT_EXPR, ctype, decl);
+  if (!contract_const_wrapper_p (decl))
+    {
+      tree ctype = TREE_TYPE (decl);
+      ctype = cp_build_qualified_type (ctype, (cp_type_quals (ctype)
+					       | TYPE_QUAL_CONST));
+      decl = build1 (VIEW_CONVERT_EXPR, ctype, decl);
+      EXPR_CONTRACT_CONST_WRAPPER_P(decl) = true;
+    }
   return decl;
 }
 

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -613,10 +613,6 @@ make_postcondition_variable (cp_expr id, tree type)
   DECL_ARTIFICIAL (decl) = true;
   DECL_SOURCE_LOCATION (decl) = id.get_location ();
 
-  /* Maybe constify the postcondition variable.  */
-  if (flag_contracts_nonattr && should_constify_contract)
-    TREE_READONLY(decl) = true;
-
   pushdecl (decl);
   return decl;
 }
@@ -2740,14 +2736,9 @@ tree view_as_const(tree decl)
 tree
 constify_contract_access(tree decl)
 {
-  /* only constifies the automatic storage variables for now.
-   * The postcondition variable is created const. Parameters need to be
-   * checked separately, and we also need to make references and *this const
-   */
 
-  /* We check if we have a variable of automatic storage duration, a parameter,
-   * a variable of automatic storage duration of reference type, or a
-   * parameter of reference type
+  /* We check if we have a variable, a parameter, a variable of reference type,
+   * or a parameter of reference type
    */
   if (!TREE_READONLY (decl)
       && (VAR_P (decl)
@@ -2777,7 +2768,11 @@ maybe_reject_param_in_postcondition (tree decl)
       && !dependent_type_p (TREE_TYPE (decl))
       && !CP_TYPE_CONST_P (TREE_TYPE (decl))
       && !(REFERENCE_REF_P (decl)
-	   && TREE_CODE (TREE_OPERAND (decl, 0)) == PARM_DECL))
+	   && TREE_CODE (TREE_OPERAND (decl, 0)) == PARM_DECL)
+	   /* Return value parameter has DECL_ARTIFICIAL flag set. The flag
+	    * presence of the flag should be sufficient to distinguish the
+	    * return value parameter in this context. */
+	   && !(DECL_ARTIFICIAL (decl)))
     {
       error_at (DECL_SOURCE_LOCATION (decl),
 		"a value parameter used in a postcondition must be const");

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2730,7 +2730,7 @@ tree view_as_const(tree decl)
       ctype = cp_build_qualified_type (ctype, (cp_type_quals (ctype)
 					       | TYPE_QUAL_CONST));
       decl = build1 (VIEW_CONVERT_EXPR, ctype, decl);
-      EXPR_CONTRACT_CONST_WRAPPER_P(decl) = true;
+      CONTRACT_CONSTIFY_EXPR_P(decl) = true;
     }
   return decl;
 }

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2730,7 +2730,8 @@ tree view_as_const(tree decl)
       ctype = cp_build_qualified_type (ctype, (cp_type_quals (ctype)
 					       | TYPE_QUAL_CONST));
       decl = build1 (VIEW_CONVERT_EXPR, ctype, decl);
-      CONTRACT_CONSTIFY_EXPR_P(decl) = true;
+      /* Mark the VCE as contract const wrapper.  */
+      decl->base.private_flag = true;
     }
   return decl;
 }

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -3204,6 +3204,18 @@ struct GTY(()) lang_decl {
 #define CONTRACT_HELPER(NODE) \
  (LANG_DECL_FN_CHECK (NODE)->contract_helper)
 
+/* In VIEW_CONVERT_EXPR, set when this node is a const wrapper.  Used to
+   constify entities inside contract assertions.  */
+
+#define EXPR_CONTRACT_CONST_WRAPPER_P(NODE) \
+  (TREE_CHECK(NODE, VIEW_CONVERT_EXPR)->base.private_flag)
+
+/* Remove any VIEW_CONVERT_EXPR that's used to constify an entity inside a
+   contract assertion.  */
+
+#define STRIP_ANY_CONTRACT_CONST_WRAPPER(EXP) \
+  (EXP) = tree_strip_any_contract_const_wrapper (CONST_CAST_TREE (EXP))
+
 /* For a FUNCTION_DECL or a VAR_DECL, the language linkage for the
    declaration.  Some entities (like a member function in a local
    class, or a local variable) do not have linkage at all, and this
@@ -8999,6 +9011,30 @@ inline void
 set_contract_const (tree t, bool constify)
 {
   TREE_LANG_FLAG_4 (CONTRACT_CHECK (t)) = constify;
+}
+
+/* Test if EXP is a contract const wrapper node.  */
+
+inline bool
+contract_const_wrapper_p (const_tree exp)
+{
+  /* A wrapper node has code VIEW_CONVERT_EXPR, and the flag
+     EXPR_LOCATION_WRAPPER_P is set.  */
+  if (TREE_CODE (exp) == VIEW_CONVERT_EXPR
+      && EXPR_CONTRACT_CONST_WRAPPER_P (exp))
+    return true;
+  return false;
+}
+
+/* Implementation of STRIP_ANY_CONTRACT_CONST_WRAPPER.  */
+
+inline tree
+tree_strip_any_contract_const_wrapper (tree exp)
+{
+  if (contract_const_wrapper_p (exp))
+    return TREE_OPERAND (exp, 0);
+  else
+    return exp;
 }
 
 /* Inline bodies.  */

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -3207,14 +3207,8 @@ struct GTY(()) lang_decl {
 /* In VIEW_CONVERT_EXPR, set when this node is a const wrapper.  Used to
    constify entities inside contract assertions.  */
 
-#define EXPR_CONTRACT_CONST_WRAPPER_P(NODE) \
+#define CONTRACT_CONSTIFY_EXPR_P(NODE) \
   (TREE_CHECK(NODE, VIEW_CONVERT_EXPR)->base.private_flag)
-
-/* Remove any VIEW_CONVERT_EXPR that's used to constify an entity inside a
-   contract assertion.  */
-
-#define STRIP_ANY_CONTRACT_CONST_WRAPPER(EXP) \
-  (EXP) = tree_strip_any_contract_const_wrapper (CONST_CAST_TREE (EXP))
 
 /* For a FUNCTION_DECL or a VAR_DECL, the language linkage for the
    declaration.  Some entities (like a member function in a local
@@ -9021,15 +9015,16 @@ contract_const_wrapper_p (const_tree exp)
   /* A wrapper node has code VIEW_CONVERT_EXPR, and the flag
      EXPR_LOCATION_WRAPPER_P is set.  */
   if (TREE_CODE (exp) == VIEW_CONVERT_EXPR
-      && EXPR_CONTRACT_CONST_WRAPPER_P (exp))
+      && CONTRACT_CONSTIFY_EXPR_P (exp))
     return true;
   return false;
 }
 
-/* Implementation of STRIP_ANY_CONTRACT_CONST_WRAPPER.  */
+/* If EXP is a CONTRACT_CONSTIFY_EXPR_P, return the wrapped expression.
+   Otherwise, do nothing. */
 
 inline tree
-tree_strip_any_contract_const_wrapper (tree exp)
+strip_contract_constify_expr (tree exp)
 {
   if (contract_const_wrapper_p (exp))
     return TREE_OPERAND (exp, 0);

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -3204,12 +3204,6 @@ struct GTY(()) lang_decl {
 #define CONTRACT_HELPER(NODE) \
  (LANG_DECL_FN_CHECK (NODE)->contract_helper)
 
-/* In VIEW_CONVERT_EXPR, set when this node is a const wrapper.  Used to
-   constify entities inside contract assertions.  */
-
-#define CONTRACT_CONSTIFY_EXPR_P(NODE) \
-  (TREE_CHECK(NODE, VIEW_CONVERT_EXPR)->base.private_flag)
-
 /* For a FUNCTION_DECL or a VAR_DECL, the language linkage for the
    declaration.  Some entities (like a member function in a local
    class, or a local variable) do not have linkage at all, and this
@@ -9012,19 +9006,17 @@ set_contract_const (tree t, bool constify)
 inline bool
 contract_const_wrapper_p (const_tree exp)
 {
-  /* A wrapper node has code VIEW_CONVERT_EXPR, and the flag
-     EXPR_LOCATION_WRAPPER_P is set.  */
-  if (TREE_CODE (exp) == VIEW_CONVERT_EXPR
-      && CONTRACT_CONSTIFY_EXPR_P (exp))
-    return true;
-  return false;
+  /* A wrapper node has code VIEW_CONVERT_EXPR, and the flag base.private_flag
+     is set. The wrapper node is used to Used to constify entities inside
+     contract assertions.  */
+  return ((TREE_CODE (exp) == VIEW_CONVERT_EXPR) && exp->base.private_flag);
 }
 
-/* If EXP is a CONTRACT_CONSTIFY_EXPR_P, return the wrapped expression.
+/* If EXP is a contract_const_wrapper_p, return the wrapped expression.
    Otherwise, do nothing. */
 
 inline tree
-strip_contract_constify_expr (tree exp)
+strip_contract_const_wrapper (tree exp)
 {
   if (contract_const_wrapper_p (exp))
     return TREE_OPERAND (exp, 0);

--- a/gcc/cp/semantics.cc
+++ b/gcc/cp/semantics.cc
@@ -12597,7 +12597,7 @@ finish_decltype_type (tree expr, bool id_expression_or_member_access_p,
 	 strip the const wrapper. Per P2900R14, "For a function f with the
 	 return type T , the result name is an lvalue of type const T , decltype(r)
 	 is T , and decltype((r)) is const T&."  */
-      expr = strip_contract_constify_expr (expr);
+      expr = strip_contract_const_wrapper (expr);
 
       if (INDIRECT_REF_P (expr)
 	  || TREE_CODE (expr) == VIEW_CONVERT_EXPR)

--- a/gcc/cp/semantics.cc
+++ b/gcc/cp/semantics.cc
@@ -12593,7 +12593,13 @@ finish_decltype_type (tree expr, bool id_expression_or_member_access_p,
       if (identifier_p (expr))
         expr = lookup_name (expr);
 
-      while (INDIRECT_REF_P (expr)
+      /* If e is a constified expression inside a contract assertion,
+	 strip the const wrapper. Per P2900R14, "For a function f with the
+	 return type T , the result name is an lvalue of type const T , decltype(r)
+	 is T , and decltype((r)) is const T&."  */
+      STRIP_ANY_CONTRACT_CONST_WRAPPER (expr);
+
+      if (INDIRECT_REF_P (expr)
 	  || TREE_CODE (expr) == VIEW_CONVERT_EXPR)
         /* This can happen when the expression is, e.g., "a.b". Just
            look at the underlying operand.  */

--- a/gcc/cp/semantics.cc
+++ b/gcc/cp/semantics.cc
@@ -12593,7 +12593,7 @@ finish_decltype_type (tree expr, bool id_expression_or_member_access_p,
       if (identifier_p (expr))
         expr = lookup_name (expr);
 
-      if (INDIRECT_REF_P (expr)
+      while (INDIRECT_REF_P (expr)
 	  || TREE_CODE (expr) == VIEW_CONVERT_EXPR)
         /* This can happen when the expression is, e.g., "a.b". Just
            look at the underlying operand.  */

--- a/gcc/cp/semantics.cc
+++ b/gcc/cp/semantics.cc
@@ -12597,7 +12597,7 @@ finish_decltype_type (tree expr, bool id_expression_or_member_access_p,
 	 strip the const wrapper. Per P2900R14, "For a function f with the
 	 return type T , the result name is an lvalue of type const T , decltype(r)
 	 is T , and decltype((r)) is const T&."  */
-      STRIP_ANY_CONTRACT_CONST_WRAPPER (expr);
+      expr = strip_contract_constify_expr (expr);
 
       if (INDIRECT_REF_P (expr)
 	  || TREE_CODE (expr) == VIEW_CONVERT_EXPR)

--- a/gcc/testsuite/g++.dg/contracts/cpp26/return_value_constness.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/return_value_constness.C
@@ -1,0 +1,59 @@
+// check that the return value has correct const qualification
+// { dg-do run }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe  " }
+
+
+#include <type_traits>
+
+bool is_constified(int &){ return false;}
+
+bool is_constified(const int &){ return true;}
+
+
+int f1(int i)
+     pre (is_constified(i))
+     pre (std::is_same<decltype(i), int>::value)
+     pre (std::is_same<decltype((i)), const int&>::value)
+
+     post (r: is_constified(r))
+     post (r: std::is_same<decltype(r), int>::value)
+     post (r: std::is_same<decltype((r)), const int&>::value)
+     { return i; };
+
+int& f2(int& i)
+    pre (is_constified(i))
+    pre (std::is_same<decltype(i), int&>::value)
+    pre (std::is_same<decltype((i)), const int&>::value)
+
+    post (r: is_constified(r))
+    post (r: std::is_same<decltype(r), int&>::value)
+    post (r: std::is_same<decltype((r)), const int&>::value)
+    {
+      static_assert(std::is_same<decltype(i), int&>::value);
+      return i;
+    }
+
+int* f2(int* i)
+    pre (std::is_same<decltype(i), int*>::value)
+    pre (std::is_same<decltype((i)),int * const>::value)
+
+    post (r: std::is_same<decltype(r), int *>::value)
+    post (r: std::is_same<decltype((r)),int * const>::value)
+    { return i;}
+
+int const * f2(int const * i)
+    pre (std::is_same<decltype(i), int const *>::value)
+    pre (std::is_same<decltype((i)),int const * const>::value)
+
+    post (r: std::is_same<decltype(r), int const *>::value)
+    post (r: std::is_same<decltype((r)),int const * const>::value)
+    { return i;}
+
+int main()
+{
+
+  int i = 4;
+  f1(i);
+  f2(i);
+
+}

--- a/gcc/testsuite/g++.dg/contracts/cpp26/return_value_constness.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/return_value_constness.C
@@ -1,6 +1,6 @@
 // check that the return value has correct const qualification
 // { dg-do run }
-// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe  " }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr " }
 
 
 #include <type_traits>

--- a/gcc/tree-core.h
+++ b/gcc/tree-core.h
@@ -1364,6 +1364,9 @@ struct GTY(()) tree_base {
        ENUM_IS_OPAQUE in
 	   ENUMERAL_TYPE
 
+      EXPR_CONTRACT_CONST_WRAPPER_P in
+	   VIEW_CONVERT_EXPR
+
    protected_flag:
 
        TREE_PROTECTED in

--- a/gcc/tree-core.h
+++ b/gcc/tree-core.h
@@ -1364,7 +1364,7 @@ struct GTY(()) tree_base {
        ENUM_IS_OPAQUE in
 	   ENUMERAL_TYPE
 
-      EXPR_CONTRACT_CONST_WRAPPER_P in
+      contract_const_wrapper_p in
 	   VIEW_CONVERT_EXPR
 
    protected_flag:


### PR DESCRIPTION
This address applying the const qualification to return value identifier. With this change, the const is applied via the constification mechanism.
Additional change is to the decltype specifier to strip multiple levels of indirect_ref and VCE. In the case of constified id-s within a contract assertion, we can have a vce of an indirect_ref. Without stripping of both layers, finish_decltype_type does not find the correct expression.
