### PR TITLE
c++, contracts: Factor constify rules and update.

### DIFF
--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -2960,6 +2960,9 @@ static tree cp_parser_function_contract_specifier_seq
 static void cp_parser_late_contract_condition
   (cp_parser *, tree, tree);
 
+static bool cp_parser_should_constify_contract
+  (const contract_modifier&);
+
 enum pragma_context {
   pragma_external,
   pragma_member,
@@ -13220,12 +13223,8 @@ cp_parser_statement (cp_parser* parser, tree in_statement_expr,
 						     0);
 
 	      /* Do we have an override for const-ification?  */
-	      bool should_constify = !flag_contracts_nonattr_noconst;
-	      if (!modifier.error_p
-		  && (modifier.mutable_p
-		      || (flag_contracts_nonattr_const_keyword
-			  && !modifier.const_p)))
-		should_constify = false;
+	      bool should_constify
+		= cp_parser_should_constify_contract (modifier);
 
 	      /* If we have a current class object, see if we need to consider
 		 it const when processing the contract condition.  */
@@ -31745,6 +31744,41 @@ cp_parser_function_contract_modifier_opt (cp_parser * parser)
   return mod;
 }
 
+/* Decide on whether this contract is const-ified, which depends on both
+   the global choice (flag_contracts_nonattr_noconst) and local MODIFIER
+   settings.
+
+   Precedence:
+     'const' keyword
+     'mutable' keyword
+     -fcontracts-nonattr-noconst.  */
+
+static bool
+cp_parser_should_constify_contract (const contract_modifier& modifier)
+{
+  /* Start with the user's base choice.  */
+  bool should_constify = !flag_contracts_nonattr_noconst;
+
+  /* We do not need to check for mutable/const conflicts that was done when
+     parsing the modifier.  */
+
+  /* Do we have an override that makes this mutable?  */
+  if (!modifier.error_p
+      && (modifier.mutable_p
+	  || (flag_contracts_nonattr_const_keyword && !modifier.const_p)))
+    should_constify = false;
+
+  /* Do we have an override that makes this const?
+     This would apply when the base choice is 'no' but we have the const
+     keyword applied to this specific contract.  */
+  if (!modifier.error_p
+      && flag_contracts_nonattr_const_keyword
+      && modifier.const_p)
+    should_constify = true;
+
+  return should_constify;
+}
+
 /* Parse a natural syntax contract specifier seq.
 
   function-contract-specifier :
@@ -31759,8 +31793,8 @@ cp_parser_function_contract_modifier_opt (cp_parser * parser)
 
    Return void_list_node if the current token doesn't start a
    contract specifier.
-
 */
+
 static tree
 cp_parser_function_contract_specifier (cp_parser *parser)
 {
@@ -31810,11 +31844,7 @@ cp_parser_function_contract_specifier (cp_parser *parser)
     cp_parser_require (parser, CPP_COLON, RT_COLON);
 
   /* Do we have an override for const-ification?  */
-  bool should_constify = !flag_contracts_nonattr_noconst;
-  if (!modifier.error_p
-      && (modifier.mutable_p
-	  || (flag_contracts_nonattr_const_keyword && !modifier.const_p)))
-    should_constify = false;
+  bool should_constify = cp_parser_should_constify_contract (modifier);
 
   tree contract;
   if (current_class_type &&
@@ -31899,7 +31929,7 @@ cp_parser_function_contract_specifier (cp_parser *parser)
   if (!flag_contracts || !flag_contracts_nonattr)
     {
       error_at (loc, "P2900 contracts are only available with %<-fcontracts%>"
-	" and %<-fcontracts-nonattr%>");
+		" and %<-fcontracts-nonattr%>");
       return error_mark_node;
     }
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification-const-1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification-const-1.C
@@ -1,0 +1,9 @@
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontracts-nonattr-const-keyword -fcontracts-nonattr-noconst " }
+
+// this is mutable because we have const keywords and it is not marked const.
+// fcontracts-nonattr-noconst is ignored.
+void good (int x) pre (x++ > 1) {}
+
+// this is const
+// again, -fcontracts-nonattr-noconst is ignored
+void bad (int x) pre const (x++ > 1) {} // { dg-error {increment of read-only location '\(const int\)x'} }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification-noconst.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification-noconst.C
@@ -1,0 +1,3 @@
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontracts-nonattr-noconst" }
+
+void good (int x) pre (x++ > 1) {} // should not be an error.


### PR DESCRIPTION
As discussed on mattermost, we were missing a check for the case `fcontracts-nonattr-noconst` +  `-fcontracts-nonattr-const-keyword` (and test cases for two `fcontracts-nonattr-noconst` conditions).

-----

This factors out the code from the two uses (contract_assert and the function contracts) and adds a rule that 'const' modifiers override any user-provided `fcontracts-nonattr-noconst`.

Test cases added for fcontracts-nonattr-noconst with and without the const modifiers enabled.


