### PR TITLE
fixing the erroneous use of cp_parser_skip_to_closing_parenthesis_1

### DIFF
--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -31841,9 +31841,10 @@ cp_parser_function_contract_specifier (cp_parser *parser)
 
   if (identifier == error_mark_node)
     {
-      cp_parser_skip_to_closing_parenthesis_1 (parser, /*recovering=*/true,
-					       CPP_CLOSE_PAREN,
-					       /*consume_paren=*/true);
+      cp_parser_skip_to_closing_parenthesis (parser,
+					     /*recovering=*/true,
+					     /*or_comma=*/false,
+					     /*consume_paren=*/true);
       return error_mark_node;
     }
 
@@ -31861,9 +31862,9 @@ cp_parser_function_contract_specifier (cp_parser *parser)
       cp_token *first = cp_lexer_peek_token (parser->lexer);
 
       /* Skip until we reach a closing token ).  */
-      cp_parser_skip_to_closing_parenthesis_1 (parser,
+      cp_parser_skip_to_closing_parenthesis (parser,
 					     /*recovering=*/false,
-					     CPP_CLOSE_PAREN,
+					     /*or_comma=*/false,
 					     /*consume_paren=*/false);
 
       cp_token *last = cp_lexer_peek_token (parser->lexer);


### PR DESCRIPTION
The parsing of contracts uses cp_parser_skip_to_closing_parenthesis_1 in two error handling branches to skip to the next closing parens.
We should be using cp_parser_skip_to_closing_parenthesis.
No tests because this isn't causing any issues, it's just poor coding.