### PR TITLE
fixing an ICE caused by a reused statement tree in contract

### DIFF
--- a/gcc/cp/cp-gimplify.cc
+++ b/gcc/cp/cp-gimplify.cc
@@ -1890,19 +1890,26 @@ cp_genericize_r (tree *stmt_p, int *walk_subtrees, void *data)
     case PRECONDITION_STMT:
     case POSTCONDITION_STMT:
       {
-	if (tree check = build_contract_check (stmt))
-	  {
-	    *stmt_p = check;
-	    return cp_genericize_r (stmt_p, walk_subtrees, data);
-	  }
-
-	/* If we didn't build a check, replace it with void_node so we don't
-	   leak contracts into GENERIC.  */
-	*stmt_p = void_node;
+	tree check = build_contract_check (stmt);
+	if (check)
+	  /* We need to genericize the contract independently of everything
+	   else we genericized until now.  When recursively genericizing, we
+	   keep a track of all the statements that have been seen.  Building a
+	   contract check will create new statements, which may reuse an
+	   already freed statement.  If such an already freed statement has
+	   been cached in p_set, we will fail to correctly genericize newly
+	   created contract tree.  */
+	  cp_genericize_tree (&check, wtd->handle_invisiref_parm_p);
+	else
+	  /* If we didn't build a check, replace it with void_node so we don't
+	  leak contracts into GENERIC.  */
+	  check = void_node;
+	*stmt_p = check;
 	*walk_subtrees = 0;
+	/* Return early and do not add the contract statement into the cache.
+	*/
+	return NULL_TREE;
       }
-      break;
-
     case USING_STMT:
       {
 	tree block = NULL_TREE;

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract_genericize.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract_genericize.C
@@ -1,0 +1,50 @@
+// check that we do not get a crash
+// { dg-do compile }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce " }
+
+
+
+struct Swapper {
+  static unsigned int swapBytes();
+  static bool isFinished();
+};
+
+
+struct Capacity {
+    Capacity(int capacity);
+    bool operator<( int rhs) const;
+    bool operator>=(int rhs) const;
+};
+
+template <class CAPACITY,  class SWAPPER>
+struct Utf32ToUtf8Translator {
+
+    CAPACITY d_capacity;
+
+    Utf32ToUtf8Translator();
+
+    static void translate();
+};
+
+template <class CAPACITY,class SWAPPER>
+void Utf32ToUtf8Translator<CAPACITY, SWAPPER>::translate()
+{
+    Utf32ToUtf8Translator<CAPACITY, SWAPPER> translator;
+
+    unsigned int uc =0;
+    while (!SWAPPER::isFinished()) {
+        uc = SWAPPER::swapBytes();
+        if (0 != uc) {
+        }
+    }
+    contract_assert( translator.d_capacity >= 1 );
+
+}
+
+void func()
+{
+    typedef Utf32ToUtf8Translator<Capacity,
+                                  Swapper> SwapTranslator;
+
+    SwapTranslator::translate();
+}


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
