### PR TITLE
addressing an ICE due to folding of original contracts

### DIFF
--- a/gcc/cp/cp-gimplify.cc
+++ b/gcc/cp/cp-gimplify.cc
@@ -1528,7 +1528,15 @@ cp_fold_function (tree fndecl)
 		    &data, NULL);
       data.pset.empty ();
     }
+
+  /* The attribute tree contains the original contracts which could be emitted
+     in multiple locations (e.g. caller side or definition side). They may also
+     be copied onto different functions. We do not want to fold contract trees
+     at this point in time. They will get folded when they are emitted.
+   */
+  tree contracts = extract_contract_attributes (fndecl);
   cp_walk_tree (&DECL_SAVED_TREE (fndecl), cp_fold_r, &data, NULL);
+  set_contract_attributes (fndecl, contracts);
 
   /* This is merely an optimization: if FNDECL has no i-e expressions,
      we'll not save c_f_d, and we can safely say that FNDECL will not

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -8970,6 +8970,7 @@ extern void check_param_in_redecl 		(tree, tree);
 extern tree view_as_const                       (tree);
 extern tree maybe_contract_wrap_call	        (tree, tree);
 extern bool emit_contract_wrapper_func          (bool);
+extern tree extract_contract_attributes 	(tree);
 extern void set_contract_attributes 		(tree, tree);
 
 /* Return the first contract in ATTRS, or NULL_TREE if there are none.  */

--- a/gcc/testsuite/g++.dg/contracts/cpp26/NonTrivialICE.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/NonTrivialICE.C
@@ -1,0 +1,21 @@
+// Test that there is no ICE with outlined contracts, caller side checks and Nontrivial types
+// in precondition checks
+// { dg-do compile }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fno-contract-checks-outlined -fcontracts-nonattr-client-check=all" }
+struct NonTrivial{
+  NonTrivial(){};
+  NonTrivial(const NonTrivial&){}
+  ~NonTrivial(){};
+  int x = 0;
+};
+
+void f(const NonTrivial s) pre(s.x >0);
+
+void f(const NonTrivial g) {};
+
+
+int main()
+{
+  NonTrivial nt;
+  f(nt);
+}

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/NonTrivialICE.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/NonTrivialICE.C
@@ -1,0 +1,26 @@
+// Test that there is no ICE with outlined contracts on a virtual function with Nontrivial types
+// in precondition checks
+// { dg-do compile }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fno-contract-checks-outlined -fcontracts-on-virtual-functions=P2900R13" }
+struct NonTrivial{
+  NonTrivial(){};
+  NonTrivial(const NonTrivial&){}
+  ~NonTrivial(){};
+  int x = 0;
+};
+
+struct S
+{
+
+  virtual void f(const NonTrivial s) pre(s.x >0 );
+
+};
+
+void S::f(const NonTrivial g) pre(g.x >0 ){};
+
+int main()
+{
+  NonTrivial nt;
+  S s;
+  s.f(nt);
+}


### PR DESCRIPTION
Currently, we keep the contracts in attribute trees on the function decl. This causes two issues :
1) when folding the function, the contracts get folded when we fold the attributes. If the contracts are emitted after the function gets folded, they may be folded twice. With the fix, we remove the contracts from the attributes, fold the remaining attributes, then apply contracts again. 
2) additionally, the same contract tree can get emitted in multiple functions. For example, with '-fno-contract-checks-outlined' in case of a virtual function, they get emitted in the body of the function and also at the call site. At the moment, we emit the same contract check statement in both places. With the fix, we make a copy of the contract statement when emitting a contract assertion so any changes to the contract statements does not affect later emits.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
