### PR TITLE
Fixing check of contracts on a declaration after definition

### DIFF
--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-redecl.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-redecl.C
@@ -86,3 +86,13 @@ struct Bar : Foo {
 void Bar::f10(int n) pre (n >10) {}; // { dg-error "mismatched contract" }
 
 
+struct NonTrivial{
+  NonTrivial(){};
+  NonTrivial(const NonTrivial&){}
+  ~NonTrivial(){};
+  int x = 0;
+};
+
+void f(const NonTrivial s) pre(s.x >0);
+void f(const NonTrivial g) {};
+void f(const NonTrivial t) pre(t.x >0);


### PR DESCRIPTION
We save the contracts from the first decl for comparison with any re-declaration. However, the stored copy refers to the parameter of the decl and the stored contracts get modified when the function decl gets genericized.
To solve the problem, we store a copy of the original contracts. The copy can't happen for deferred contracts so we only save them when the contracts are not deferred. This means friend declarations can not work correctly. However, we already do not have a solution for recognising mismatched contracts on friend declarations.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
