### PR TITLE
adding Invoke_default_contract_violation_handler

### DIFF
--- a/libstdc++-v3/include/std/contracts
+++ b/libstdc++-v3/include/std/contracts
@@ -106,7 +106,7 @@ namespace contracts
 	evaluation_semantic semantic() const noexcept { return _M_evaluation_semantic; }
 	};
 
-//void invoke_default_contract_violation_handler(const contract_violation&);
+  void invoke_default_contract_violation_handler(const contract_violation&);
 
 } // namespace contracts
 

--- a/libstdc++-v3/include/std/contracts
+++ b/libstdc++-v3/include/std/contracts
@@ -106,7 +106,7 @@ namespace contracts
 	evaluation_semantic semantic() const noexcept { return _M_evaluation_semantic; }
 	};
 
-  void invoke_default_contract_violation_handler(const contract_violation&);
+  void invoke_default_contract_violation_handler(const contract_violation&) noexcept;
 
 } // namespace contracts
 

--- a/libstdc++-v3/src/experimental/contract26.cc
+++ b/libstdc++-v3/src/experimental/contract26.cc
@@ -29,8 +29,7 @@
 # include <cxxabi.h>
 #endif
 
-__attribute__ ((weak)) void
-handle_contract_violation (const std::contracts::contract_violation &violation) noexcept
+void __handle_contract_violation(const std::contracts::contract_violation &violation) noexcept
 {
 #if _GLIBCXX_HOSTED && _GLIBCXX_VERBOSE
 
@@ -112,11 +111,43 @@ handle_contract_violation (const std::contracts::contract_violation &violation) 
 #endif
 }
 
+namespace std _GLIBCXX_VISIBILITY(default)
+{
+_GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+namespace contracts
+{
+
+void invoke_default_contract_violation_handler(const std::contracts::contract_violation& violation)
+{
+  return __handle_contract_violation(violation);
+}
+
+}
+}
+
+__attribute__ ((weak)) void
+handle_contract_violation (const std::contracts::contract_violation &violation)
+{
+  return __handle_contract_violation(violation);
+}
+
 #if _GLIBCXX_INLINE_VERSION
 // The compiler expects the contract_violation class to be in an unversioned
 // namespace, so provide a forwarding function with the expected symbol name.
 extern "C" void
-_Z25handle_contract_violationRKNSt12contract_violationE
+_Z25handle_contract_violationRKNSt9contracts18contract_violationE
 (const std::contracts::contract_violation &violation)
 { handle_contract_violation(violation); }
+
+extern "C" void
+_Z27__handle_contract_violationRKNSt9contracts18contract_violationE
+(const std::contracts::contract_violation &violation)
+{ __handle_contract_violation(violation); }
+
+extern "C" void
+_Z41invoke_default_contract_violation_handlerRKNSt9contracts18contract_violationE
+(const std::contracts::contract_violation &violation)
+{ invoke_default_contract_violation_handler(violation); }
+
 #endif

--- a/libstdc++-v3/src/experimental/contract26.cc
+++ b/libstdc++-v3/src/experimental/contract26.cc
@@ -118,7 +118,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 namespace contracts
 {
 
-void invoke_default_contract_violation_handler(const std::contracts::contract_violation& violation)
+void invoke_default_contract_violation_handler(const std::contracts::contract_violation& violation) noexcept
 {
   return __handle_contract_violation(violation);
 }

--- a/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh.cc
@@ -1,0 +1,39 @@
+// Copyright (C) 2020-2025 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+// { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
+// { dg-do run { target c++2a } }
+
+#include <contracts>
+#include <testsuite_hooks.h>
+
+bool custom_called = 1;
+
+
+void handle_contract_violation(const std::contracts::contract_violation& v)
+{
+  invoke_default_contract_violation_handler(v);
+}
+
+void f(int i) pre (i>10) {};
+
+int main()
+{
+  f(0);
+  VERIFY(custom_called == 1);
+}
+// { dg-output "contract violation in function f at .*(\n|\r\n|\r)" }


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
