### PR TITLE
c++, libstdc++, contracts: Alter object layout.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2061,32 +2061,32 @@ get_p9600_contract_violation_fields ()
 {
   tree fields = NULL_TREE;
   /* Must match <contracts>:
-     class contract_violation {
-	int version;
-	__vendor_ext* ext;
-	const char* _M_comment;
-	detection_mode _M_detection_mode;
-	assertion_kind _M_assertion_kind;
-	source_location _M_source_location;
-	evaluation_semantic _M_evaluation_semantic;
-     }
+  class contract_violation {
+    uint16_t _M_version;
+    assertion_kind _M_assertion_kind;
+    evaluation_semantic _M_evaluation_semantic;
+    detection_mode _M_detection_mode;
+    const char* _M_comment;
+    std::source_location _M_source_location;
+    __vendor_ext* _M_ext;
+  };
     If this changes, also update the initializer in
     build_contract_violation.  */
-  const tree types[] = { integer_type_node,
-			 nullptr_type_node,
+  const tree types[] = { uint16_type_node,
+			 uint16_type_node,
+			 uint16_type_node,
+			 uint16_type_node,
 			 const_string_type_node,
-			 integer_type_node,
-			 integer_type_node,
 			 get_contracts_source_location_type(),
 			 integer_type_node
 			};
- const char *names[] = { "version",
-			 "_M_ext",
-			 "_M_comment",
-			 "_M_detection_mode",
+ const char *names[] = { "_M_version",
 			 "_M_assertion_kind",
+			 "_M_evaluation_semantic",
+			 "_M_detection_mode",
+			 "_M_comment",
 			 "_M_source_location",
-			 "_M_evaluation_semantic"
+			 "_M_ext",
 			};
   unsigned n = 0;
   for (tree type : types)
@@ -2249,8 +2249,8 @@ get_contract_assertion_kind(tree contract)
 
 /* Get contract_evaluation_semantic of the specified contract.  */
 
-static int
-get_evaluation_semantic(tree contract)
+static uint16_t
+get_evaluation_semantic (tree contract)
 {
   contract_semantic semantic = get_contract_semantic (contract);
 
@@ -2281,27 +2281,28 @@ get_evaluation_semantic(tree contract)
     }
 }
 
-/* Build P2900R7 contract_violation layout compatible object. */
+/* Build a p2900 contract_violation layout compatible object. */
 
 static tree
 build_contract_violation_p2900 (tree contract, bool is_const)
 {
-  int assertion_kind = get_contract_assertion_kind (contract);
-  int evaluation_semantic = get_evaluation_semantic (contract);
+  uint16_t version = 1;
+  uint16_t assertion_kind = get_contract_assertion_kind (contract);
+  uint16_t evaluation_semantic = get_evaluation_semantic (contract);
 
   /* we hardcode CDM_PREDICATE_FALSE because that's all we support for now */
-  int detection_mode = CDM_PREDICATE_FALSE;
+  uint16_t detection_mode = contract_detection_mode::CDM_PREDICATE_FALSE;
 
   /* Must match the type layout in get_pseudo_contract_violation_type.  */
   tree ctor = build_constructor_va
     (get_pseudo_contract_violation_type (), 7,
-     NULL_TREE, build_int_cst (integer_type_node, 0), 		// version
-     NULL_TREE, build_int_cst (nullptr_type_node, 0),   // __vendor_ext
+     NULL_TREE, build_int_cst (uint16_type_node, version),
+     NULL_TREE, build_int_cst (uint16_type_node, assertion_kind),
+     NULL_TREE, build_int_cst (uint16_type_node, evaluation_semantic),
+     NULL_TREE, build_int_cst (uint16_type_node, detection_mode),
      NULL_TREE, CONTRACT_COMMENT (contract),
-     NULL_TREE, build_int_cst (integer_type_node, detection_mode),
-     NULL_TREE, build_int_cst (integer_type_node, assertion_kind),
      NULL_TREE, build_contracts_source_location (EXPR_LOCATION (contract)),
-     NULL_TREE, build_int_cst (integer_type_node, evaluation_semantic));
+     NULL_TREE, build_int_cst (nullptr_type_node, 0));  // __vendor_ext
 
   TREE_READONLY (ctor) = true;
   TREE_CONSTANT (ctor) = true;
@@ -2618,8 +2619,9 @@ build_contract_check_p2900 (tree contract)
 		     /*protect=*/1, /*want_type=*/0, tf_warning_or_error);
       tree r  = build_class_member_access_expr (violation, memb, NULL_TREE,
 						false, tf_warning_or_error);
-      r = cp_build_init_expr (r, build_int_cst (integer_type_node,
-					    CDM_EVAL_EXCEPTION));
+      r = cp_build_init_expr (r,
+			      build_int_cst (uint16_type_node,
+					     CDM_EVAL_EXCEPTION));
       finish_expr_stmt (r);
       build_contract_handler_call (build_address (violation), noexcept_wrap);
 #else

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -22,6 +22,8 @@ along with GCC; see the file COPYING3.  If not see
 #ifndef GCC_CP_CONTRACT_H
 #define GCC_CP_CONTRACT_H
 
+#include <cstdint>
+
 /* Contract levels approximate the complexity of the expression.  */
 
 enum contract_level
@@ -99,7 +101,7 @@ struct contract_role
 /* P2900 contract clasification */
 /* Must match relevant enums in <contracts> header  */
 
-enum constract_assertion_kind {
+enum constract_assertion_kind : uint16_t {
   CAK_INVALID = 0 ,
   CAK_PRE = 1 ,
   CAK_POST = 2 ,
@@ -108,8 +110,8 @@ enum constract_assertion_kind {
   CAK_CASSERT = 5,
 };
 
-/* Per P2900R11.  */
-enum contract_evaluation_semantic {
+/* Per P2900R14 + D3290R3 + extensions.  */
+enum contract_evaluation_semantic : uint16_t {
   CES_INVALID = 0,
   CES_IGNORE = 1,
   CES_OBSERVE = 2,
@@ -119,7 +121,7 @@ enum contract_evaluation_semantic {
   CES_NOEXCEPT_OBSERVE = 6
 };
 
-enum constract_detection_mode {
+enum contract_detection_mode : uint16_t {
   CDM_UNSPECIFIED = 0,
   CDM_PREDICATE_FALSE = 1,
   CDM_EVAL_EXCEPTION = 2

--- a/libstdc++-v3/include/std/contracts
+++ b/libstdc++-v3/include/std/contracts
@@ -42,8 +42,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
 namespace contracts
 {
-
-// From P3290
+  // From D3290R3
   struct __location_info{
     std::source_location _M_source_location;
     explicit __location_info(std::source_location __location)
@@ -73,35 +72,39 @@ namespace contracts
       const std::source_location &__location = std::source_location::current()) noexcept;
 
 
-  // From P2900R11
-  enum class assertion_kind {
+  // From P2900R14 + D3290R3
+
+  enum class assertion_kind : uint16_t {
     pre = 1,
     post = 2,
     assert = 3,
-    // From P3290
+    // From D3290R3
     manual = 4,
-    cassert = 5
-    /* to be extended with implementation−defined values and by future extensions */
-    /* Implementation−defined values should have a minimum value of 1000. */
-    };
+    cassert = 5,
 
-  enum class evaluation_semantic {
-      ignore = 1,
-      observe = 2,
-      enforce = 3,
-      quick_enforce = 4
-	// not explicitly provided
-	// assume = 5
-	// expected as a future extension
-	/* to be extended with implementation−defined values and by future extensions */
-	/* Implementation−defined values should have a minimum value of 1000. */
+    /* Implementation−defined values should have a minimum value of 1000. */
   };
 
-  enum class detection_mode  {
-  // From P3290
+  enum class evaluation_semantic : uint16_t {
+    ignore = 1,
+    observe = 2,
+    enforce = 3,
+    quick_enforce = 4,
+
+    /* FIXME: Implementation−defined values should have a minimum value of 1000
+      but we cannot [currently] accommodate > 7.
+      Experimental only (no paper).  */
+    noexcept_enforce = 5,
+    noexcept_observe = 6,
+    force_quick = 7,
+  };
+
+  enum class detection_mode : uint16_t {
+    // From D3290R3
     unspecified = 0,
     predicate_false = 1,
-    evaluation_exception = 2
+    evaluation_exception = 2,
+    manual = 3
     /* to be extended with implementation−defined values and by future extensions
 	 Implementation−defined values should have a minimum value of 1000. */
   };
@@ -109,27 +112,22 @@ namespace contracts
   using __vendor_ext = void;
 
   class contract_violation {
-    int _M_version;
-    __vendor_ext* _M_ext;
-    const char* _M_comment;
-    detection_mode _M_detection_mode;
+    uint16_t _M_version;
     assertion_kind _M_assertion_kind;
-    std::source_location _M_source_location;
     evaluation_semantic _M_evaluation_semantic;
+    detection_mode _M_detection_mode;
+    const char* _M_comment;
+    std::source_location _M_source_location;
+    __vendor_ext* _M_ext;
 
     contract_violation(evaluation_semantic __semantic,
 		       const std::source_location &__location,
-		       const char* __comment):
-      _M_version(0),
-      _M_ext(nullptr),
-      _M_comment(__comment),
-      _M_detection_mode(detection_mode::unspecified),
-      _M_assertion_kind(assertion_kind::manual),
-      _M_source_location(__location),
-      _M_evaluation_semantic(__semantic)
-    {
-
-    }
+		       const char* __comment)
+      : _M_version(0), _M_assertion_kind(assertion_kind::manual),
+        _M_evaluation_semantic(__semantic),
+        _M_detection_mode(detection_mode::unspecified),
+        _M_comment(__comment), _M_source_location(__location),
+        _M_ext(nullptr) { }
 
     friend void handle_enforced_contract_violation(
 	const char*,
@@ -155,29 +153,28 @@ namespace contracts
 
   public:
     // cannot be copied or moved
-	contract_violation(const contract_violation&) = delete;
+    contract_violation(const contract_violation&) = delete;
 
-	// cannot be assigned to
-	contract_violation& operator=(const contract_violation&) = delete;
+    // cannot be assigned to
+    contract_violation& operator=(const contract_violation&) = delete;
 
-	const char* comment() const noexcept { return _M_comment; }
-	detection_mode mode() const noexcept { return _M_detection_mode; }
-	std::exception_ptr evaluation_exception () const noexcept {
-	  if (_M_detection_mode == std::contracts::detection_mode::evaluation_exception)
-	    return std::current_exception ();
-	  return nullptr;
-	}
-	bool is_terminating () const noexcept {
-	  return _M_evaluation_semantic == std::contracts::evaluation_semantic::enforce
-	        || _M_evaluation_semantic == std::contracts::evaluation_semantic::quick_enforce;
-	}
-	assertion_kind kind() const noexcept { return _M_assertion_kind; }
-	std::source_location location() const noexcept { return _M_source_location; }
-	evaluation_semantic semantic() const noexcept { return _M_evaluation_semantic; }
+    const char* comment() const noexcept { return _M_comment; }
+    detection_mode mode() const noexcept { return _M_detection_mode; }
+    std::exception_ptr evaluation_exception () const noexcept {
+      if (_M_detection_mode == std::contracts::detection_mode::evaluation_exception)
+	return std::current_exception ();
+      return nullptr;
+    }
+    bool is_terminating () const noexcept {
+      return _M_evaluation_semantic == std::contracts::evaluation_semantic::enforce
+	    || _M_evaluation_semantic == std::contracts::evaluation_semantic::quick_enforce;
+    }
+    assertion_kind kind() const noexcept { return _M_assertion_kind; }
+    std::source_location location() const noexcept { return _M_source_location; }
+    evaluation_semantic semantic() const noexcept { return _M_evaluation_semantic; }
   };
 
   void invoke_default_contract_violation_handler(const contract_violation&) noexcept;
-
 
 } // namespace contracts
 


### PR DESCRIPTION
The existing "temporary" object layout can, in my view be improved greatly (assuming we even keep it)
There are some objectives in moving forward...
 1. allow for the possibility that we might want smaller objects on some platforms
 2. do not use nullptr as a boolean - that's expensive in space

so.. I am keeping the layout 'linear' but putting the required sub-objects at the start and the less-likely used ones later

ideas for producing reduced objects to follow ...

... perhaps I should have used `uint_least16_t` rather than `uint16_t` - but, first let's see if this is a dreadful idea for some reason ... 
