### PR TITLE
c++, contracts: Parse and ignore std attributes on contracts.

### DIFF
--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -31963,6 +31963,16 @@ cp_parser_contract_assert (cp_parser *parser, cp_token *token)
   contract_modifier modifier
     = cp_parser_function_contract_modifier_opt (parser);
 
+  location_t attrs_loc = cp_lexer_peek_token (parser->lexer)->location;
+  tree std_attrs = cp_parser_std_attribute_spec_seq (parser);
+  if (std_attrs)
+    {
+      attrs_loc = make_location (attrs_loc, attrs_loc, input_location);
+      warning_at (attrs_loc, OPT_Wattributes, "attributes are ignored on"
+		  " contract assertions");
+      std_attrs = NULL_TREE;
+    }
+
   matching_parens parens;
   parens.require_open (parser);
   /* Enable location wrappers when parsing contracts.  */
@@ -32086,6 +32096,16 @@ cp_parser_function_contract_specifier (cp_parser *parser)
   /* Parse experimental modifiers on C++26 contracts.  */
   contract_modifier modifier
     = cp_parser_function_contract_modifier_opt (parser);
+
+  location_t attrs_loc = cp_lexer_peek_token (parser->lexer)->location;
+  tree std_attrs = cp_parser_std_attribute_spec_seq (parser);
+  if (std_attrs)
+    {
+      attrs_loc = make_location (attrs_loc, attrs_loc, input_location);
+      warning_at (attrs_loc, OPT_Wattributes, "attributes are ignored on"
+		  " function contract specifiers");
+      std_attrs = NULL_TREE;
+    }
 
   matching_parens parens;
   parens.require_open (parser);

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-warn-attributes.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-warn-attributes.C
@@ -1,0 +1,14 @@
+// { dg-options "-std=c++26 -fcontracts -fcontracts-nonattr" }
+
+int foo (int x)
+pre [[unlikley]] ( x > 41 )  // { dg-warning "attributes are ignored on function contract specifiers" }
+{
+  return x + 1;
+}
+
+int main(int ac, char *av[])
+{
+   int i = ac;
+   contract_assert [[deprecated]] (i == 3);  // { dg-warning "attributes are ignored on contract assertions" }
+  return i;
+}


### PR DESCRIPTION
Having done this, my next plan is to ask folks if there's any point in having them in C++26, since there are no uses for them - and adding them later if there is some use is a non-breaking change (at least AFAICT).

-------

This applies to contract assertions and function contract specifiers. We parse, ignore and warn that we've ignored.

(there are none currently specified to apply - and we've passed the
 time to add new things .. so )

