### PR TITLE
adding missing contract header in cassert

### DIFF
--- a/libstdc++-v3/include/c_global/cassert
+++ b/libstdc++-v3/include/c_global/cassert
@@ -46,8 +46,9 @@
 #if defined NDEBUG || ! defined ASSERT_USES_CONTRACTS
 #include_next <assert.h>
 #else // ASSERT_USES_CONTRACTS
+#include <contracts>
 #undef assert
-#  define assert(...)                                                   \
+#define assert(...)                                                     \
      (void)((__VA_ARGS__)                                               \
          ? (void)(true ? true : bool(__VA_ARGS__))                      \
          : std::contracts::__handle_assert_contract_violation (#__VA_ARGS__))

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation.cc
@@ -17,7 +17,6 @@
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #define ASSERT_USES_CONTRACTS
@@ -39,6 +38,6 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:38: i == 4.*" }
+// { dg-output "contract violation in function int main.* at .*:37: i == 4.*" }
 // { dg-output "assertion_kind: cassert, semantic: enforce, mode: unspecified, terminating: yes" }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation2.cc
@@ -16,7 +16,6 @@
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #define ASSERT_USES_CONTRACTS

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation3.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation3.cc
@@ -16,7 +16,6 @@
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #define ASSERT_USES_CONTRACTS

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation4.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation4.cc
@@ -17,7 +17,6 @@
 // { dg-do run { target c++2a } }
 
 #define NDEBUG
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #include <cassert>

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation5.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation5.cc
@@ -16,7 +16,6 @@
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #include <cassert>

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation6.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation6.cc
@@ -18,7 +18,6 @@
 
 #define NDEBUG
 #define ASSERT_USES_CONTRACTS
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #include <cassert>

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation7.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation7.cc
@@ -16,7 +16,6 @@
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
-#include <contracts>
 #include <exception>
 #include <cstdlib>
 #define ASSERT_USES_CONTRACTS
@@ -38,6 +37,6 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:37: i == 4.*" }
+// { dg-output "contract violation in function int main.* at .*:36: i == 4.*" }
 // { dg-output "assertion_kind: cassert, semantic: enforce, mode: unspecified, terminating: yes" }
 


### PR DESCRIPTION
Adding missing contracts header to cassert. Removing the same include from tests.
