### PR TITLE
moving a test to compile time only test

### DIFF
--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation2.cc
@@ -14,7 +14,7 @@
 // <http://www.gnu.org/licenses/>.
 
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
-// { dg-do run { target c++2a } }
+// { dg-do compile { target c++2a } }
 
 #include <exception>
 #include <cstdlib>


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
