### PR TITLE
Contract GitHub issue 21

### DIFF
--- a/gcc/cp/call.cc
+++ b/gcc/cp/call.cc
@@ -359,12 +359,11 @@ set_flags_from_callee (tree call)
 }
 
 tree
-build_call_a (tree function, int n, tree *argarray)
+build_call_a_1(tree function, int n, tree *argarray)
 {
   tree decl;
   tree result_type;
   tree fntype;
-  int i;
 
   function = build_addr_func (function, tf_warning_or_error);
 
@@ -382,6 +381,23 @@ build_call_a (tree function, int n, tree *argarray)
 
   decl = get_callee_fndecl (function);
 
+  require_complete_eh_spec_types (fntype, decl);
+
+  TREE_HAS_CONSTRUCTOR (function) = (decl && DECL_CONSTRUCTOR_P (decl));
+
+  return function;
+}
+
+tree
+build_call_a (tree function, int n, tree *argarray)
+{
+  int i;
+  tree decl;
+
+  function = build_call_a_1 (function, n, argarray);
+
+  decl = get_callee_fndecl (function);
+
   if (decl && !TREE_USED (decl))
     {
       /* We invoke build_call directly for several library
@@ -393,10 +409,6 @@ build_call_a (tree function, int n, tree *argarray)
 			       "__", 2));
       mark_used (decl);
     }
-
-  require_complete_eh_spec_types (fntype, decl);
-
-  TREE_HAS_CONSTRUCTOR (function) = (decl && DECL_CONSTRUCTOR_P (decl));
 
   /* Don't pass empty class objects by value.  This is useful
      for tags in STL, which are used to control overload resolution.

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2984,16 +2984,7 @@ build_thunk_like_call (tree function, int n, tree *argarray)
   decl = get_callee_fndecl (function);
 
   if (decl && !TREE_USED (decl))
-    {
-      /* We invoke build_call directly for several library
-	 functions.  These may have been declared normally if
-	 we're building libgcc, so we can't just check
-	 DECL_ARTIFICIAL.  */
-      gcc_assert (DECL_ARTIFICIAL (decl)
-		  || !strncmp (IDENTIFIER_POINTER (DECL_NAME (decl)),
-			       "__", 2));
       mark_used (decl);
-    }
 
   require_complete_eh_spec_types (fntype, decl);
 

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2966,33 +2966,13 @@ start_function_contracts (tree fndecl)
 tree
 build_thunk_like_call (tree function, int n, tree *argarray)
 {
-  tree decl;
-  tree result_type;
-  tree fntype;
 
-  function = build_addr_func (function, tf_warning_or_error);
+  function = build_call_a_1 (function, n, argarray);
 
-  gcc_assert (TYPE_PTR_P (TREE_TYPE (function)));
-  fntype = TREE_TYPE (TREE_TYPE (function));
-  gcc_assert (FUNC_OR_METHOD_TYPE_P (fntype));
-  result_type = TREE_TYPE (fntype);
-
-  /* An rvalue has no cv-qualifiers.  */
-  if (SCALAR_TYPE_P (result_type) || VOID_TYPE_P (result_type))
-    result_type = cv_unqualified (result_type);
-
-  function = build_call_array_loc (input_location,
-				   result_type, function, n, argarray);
-  set_flags_from_callee (function);
-
-  decl = get_callee_fndecl (function);
+  tree decl = get_callee_fndecl (function);
 
   if (decl && !TREE_USED (decl))
       mark_used (decl);
-
-  require_complete_eh_spec_types (fntype, decl);
-
-  TREE_HAS_CONSTRUCTOR (function) = (decl && DECL_CONSTRUCTOR_P (decl));
 
   CALL_FROM_THUNK_P (function) = true;
 

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2950,13 +2950,17 @@ start_function_contracts (tree fndecl)
 }
 
 /* Build and return a thunk like call to FUNCTION using the supplied
-  arguments.  The call is like a thunk call in the fact that we do not
-  want to create aditional copies of the arguments. However, we can
-  not simply reuse the thunk machinery as it does more than we want.
-  Instead, we reuse build_call_a, modulo special handling for empty
-  classes that relies on the function being marked as DECL_THUNK_P.
-  We also mark the call as a thunk call allows for correct gimplification
-  of the arguments.
+ arguments.  The call is like a thunk call in the fact that we do not
+ want to create additional copies of the arguments. However, we can
+ not simply reuse the thunk machinery as it does more than we want.
+ More specifically, we don't want to mark the calling function as
+ `DECL_THUNK_P`, we only want the special treatment for the parameters
+ of the call we are about to generate.
+ We reuse most of build_call_a, modulo special handling for empty
+ classes which relies on `DECL_THUNK_P` to know that the call we're building
+ is going to be a thunk call.
+ We also mark the call as a thunk call to allow for correct gimplification
+ of the arguments.
  */
 
 tree

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -6978,6 +6978,7 @@ extern tree build_conditional_expr		(const op_location_t &,
 extern tree build_addr_func			(tree, tsubst_flags_t);
 extern void set_flags_from_callee		(tree);
 extern tree build_call_a			(tree, int, tree*);
+extern tree build_call_a_1			(tree, int, tree*);
 extern tree build_call_n			(tree, int, ...);
 extern bool null_ptr_cst_p			(tree);
 extern bool null_member_pointer_value_p		(tree);

--- a/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param.C
@@ -1,0 +1,25 @@
+// check that we do not ICE with an empty nontrivial parameter
+// { dg-do run }
+// { dg-options "-std=c++2b -fcontracts -std=c++23 -fcontracts-nonattr " }
+
+struct NTClass {
+  NTClass(){};
+  NTClass(const NTClass&){}
+  ~NTClass(){};
+};
+
+struct Empty {};
+
+void f (const NTClass i) pre (true){
+}
+
+void g (const Empty i) pre (true){
+}
+int main(){
+
+  NTClass n;
+  f(n);
+  g(Empty{});
+
+
+}

--- a/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param2.C
@@ -1,0 +1,24 @@
+// check that we do not ICE with an empty nontrivial parameter
+// { dg-do compile }
+// { dg-options "-std=c++2b -fcontracts -std=c++23 -fcontracts-nonattr " }
+struct NTClass {
+  NTClass(){};
+  ~NTClass(){};
+};
+
+struct Empty {};
+
+struct PostCond {
+  void f (const NTClass i)
+    post ( true);
+
+  void g (const Empty i)
+    post ( true);
+
+};
+
+void
+PostCond::f (NTClass i){}
+
+void
+PostCond::g (Empty i){}


### PR DESCRIPTION
We currently attempt to use CALL_FROM_THUNK_P to avoid making additional
copies of the arguments when invoking wrappers or pre/post outlined calls.
However, the avoiding additional copy part of thunk machinery also relies
on the function making the call being marked as DECL_THUNK_P within
(at least) build_call_a. We can not mark the calling functions as
DECL_THUNK_P without creating other problems. Instead, this patch creates a
contracts version of build_call_a that does not check for DECL_THUNK_P.
Downside is that we may lose some optimisation for empty classes.
This can be improved if necessary.
