### PR TITLE
more P3290 fixes

### DIFF
--- a/libstdc++-v3/include/c_global/cassert
+++ b/libstdc++-v3/include/c_global/cassert
@@ -44,7 +44,10 @@
 
 #include <bits/c++config.h>
 #if defined NDEBUG || ! defined ASSERT_USES_CONTRACTS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic" // include_next
 #include_next <assert.h>
+#pragma GCC diagnostic pop
 #else // ASSERT_USES_CONTRACTS
 #include <contracts>
 #undef assert

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation.cc
@@ -14,6 +14,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case when ASSERT_USES_CONTRACTS is defined and NDEBUG is not defined behaves correctly.
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
@@ -38,6 +40,6 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:37: i == 4.*" }
+// { dg-output "contract violation in function int main.* at .*:39: i == 4.*" }
 // { dg-output "assertion_kind: cassert, semantic: enforce, mode: unspecified, terminating: yes" }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation2.cc
@@ -13,6 +13,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that assert behaves according to P2264R7
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do compile { target c++2a } }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation3.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation3.cc
@@ -13,6 +13,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that assert behaves according to P2264R7
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation4.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation4.cc
@@ -13,6 +13,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case when NDEBUG is defined and ASSERT_USES_CONTRACTS isn't behaves correctly.
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation5.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation5.cc
@@ -13,6 +13,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case when neither ASSERT_USES_CONTRACTS nor NDEBUG are defined behaves correctly.
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
@@ -37,5 +39,5 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "int main.*: Assertion .*i == 4.* failed.*" }
+// { dg-output "main.*: Assertion .*i == 4.* failed.*" }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation6.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation6.cc
@@ -13,6 +13,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case when both ASSERT_USES_CONTRACTS and NDEBUG are defined behaves correctly.
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation7.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation7.cc
@@ -13,6 +13,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case when assert.h header is included works as expected
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
@@ -37,6 +39,6 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:36: i == 4.*" }
+// { dg-output "contract violation in function.*main.* at .*:38: i == 4.*" }
 // { dg-output "assertion_kind: cassert, semantic: enforce, mode: unspecified, terminating: yes" }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation.cc
@@ -15,6 +15,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case with user provided contract violation handler works as expected
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation2.cc
@@ -15,6 +15,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case of contract violation handler throwing an exception works as expected
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
@@ -43,5 +45,5 @@ int main()
   }
   VERIFY( exception_thrown == true);
 }
-// { dg-output "contract violation in function int main.* at .*:38: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:40: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: enforce, mode: unspecified, terminating: yes" }

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation3.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation3.cc
@@ -15,6 +15,9 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case of contract violation handler throwing an exception works as expected for
+// nothrow overload.
+// Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=ignore" }
 // { dg-do run { target c++2a } }
 
@@ -51,5 +54,5 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:46: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:49: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: enforce, mode: unspecified, terminating: yes" }

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation4.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_enforced_contract_violation4.cc
@@ -15,6 +15,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that nothrow overload of handle_enforced_contract_violation works as expected.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=quick_enforce" }
 // { dg-do run { target c++2a } }
 
@@ -37,5 +38,5 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:36: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:37: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: enforce, mode: unspecified, terminating: yes" }

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation.cc
@@ -15,6 +15,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that handle_observed_contract_violation works as expected.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce" }
 // { dg-do run { target c++2a } }
 
@@ -24,5 +25,5 @@ int main()
 {
   std::contracts::handle_observed_contract_violation("test comment");
 }
-// { dg-output "contract violation in function int main.* at .*:25: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:26: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: observe, mode: unspecified, terminating: no" }

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation2.cc
@@ -15,6 +15,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that handle_observed_contract_violation works as expected in presence of an exception.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce" }
 // { dg-do run { target c++2a } }
 
@@ -41,5 +42,5 @@ int main()
   }
   VERIFY( exception_thrown == true);
 }
-// { dg-output "contract violation in function int main.* at .*:36: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:37: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: observe, mode: unspecified, terminating: no" }

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation3.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation3.cc
@@ -15,6 +15,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that a case of contract violation handler throwing an exception works as expected for
+// nothrow overload.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=ignore" }
 // { dg-do run { target c++2a } }
 
@@ -50,5 +52,5 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "contract violation in function int main.* at .*:45: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:47: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: observe, mode: unspecified, terminating: no" }

--- a/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation4.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_observed_contract_violation4.cc
@@ -15,6 +15,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// Check that nothrow overload of handle_observed_contract_violation works as expected.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=quick_enforce" }
 // { dg-do run { target c++2a } }
 
@@ -25,5 +26,5 @@ int main()
 
   std::contracts::handle_observed_contract_violation(std::nothrow, "test comment");
 }
-// { dg-output "contract violation in function int main.* at .*:26: test comment.*" }
+// { dg-output "contract violation in function.*main.* at .*:27: test comment.*" }
 // { dg-output "assertion_kind: manual, semantic: observe, mode: unspecified, terminating: no" }

--- a/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh.cc
@@ -15,6 +15,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// check that invoke_default_contract_violation_handler works as expected
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 

--- a/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh2.cc
@@ -15,6 +15,7 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// check that default contract violation is not invoked if not explicitly invoked
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
 
@@ -54,8 +55,6 @@ void handle_contract_violation(const std::contracts::contract_violation& v)
 {
   custom_called = true;
 }
-
-
 
 
 void f(int i) pre (i>10) {};


### PR DESCRIPTION
removing spurious diagnostic for #include_next
adding description of tests
fixing a test that wasn't testing what it was intending to test

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
