### PR TITLE
c++, contracts: Rework source locations.

### DIFF
--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -8850,6 +8850,7 @@ extern tree process_stmt_hotness_attribute	(tree, location_t);
 extern tree build_assume_call			(location_t, tree);
 extern tree process_stmt_assume_attribute	(tree, tree, location_t);
 extern bool simple_empty_class_p		(tree, tree, tree_code);
+extern tree build_source_location_impl		(location_t, tree, tree);
 extern tree fold_builtin_source_location	(const_tree);
 extern tree get_source_location_impl_type	();
 extern tree cp_fold_immediate			(tree *, mce_value,

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/contracts-pre4.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/contracts-pre4.C
@@ -78,18 +78,18 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output "contract violation in function Base::f at .*.C:7: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*.C:7: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*.C:7: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*.C:7: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Base: 13(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*.C:7: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*.C:7: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*.C:7: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*.C:7: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Child0: 13(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*.C:23: a > 14.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*.C:23: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child1::f.int. at .*.C:23: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child1::f.int. at .*.C:23: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "Child1: 27(\n|\r\n|\r)" }
 // { dg-output "Child2: 31(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child3::f at .*.C:45: a > 0.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child3::f at .*.C:45: a > 0.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child3::f.int. at .*.C:45: a > 0.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child3::f.int. at .*.C:45: a > 0.*(\n|\r\n|\r)" }
 // { dg-output "Child3: 40(\n|\r\n|\r)" }
 // { dg-output "Child3: 41(\n|\r\n|\r)" }
 // { dg-output "Child4: 50(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func.C
@@ -62,33 +62,33 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Base: 3(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Child0: 3(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 14.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child1::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child1::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "Child1: 17(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int GChild1::f.int. at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int GChild1::f.int. at .*: a > 6.*(\n|\r\n|\r)" }
 // { dg-output "GChild1: 103(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int GChild2::f.int. at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int GChild2::f.int. at .*: a > 30.*(\n|\r\n|\r)" }
 // { dg-output "GChild2: 207(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Base.: 1(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Child0.: 1(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Child1::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Child1.: 11(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int GChild1::f.int. at .*: a > 6.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.GChild1.: 101(\n|\r\n|\r)" }
-// { dg-output "contract violation in function .* at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int GChild2::f.int. at .*: a > 30.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.GChild2.: 201(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func1.C
@@ -68,33 +68,33 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Base: 3(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "Child0: 3(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Child1::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Child1::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "Child1: 17(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T GChild1::f.int. at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T GChild1::f.int. at .*: a > 6.*(\n|\r\n|\r)" }
 // { dg-output "GChild1: 103(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T GChild2::f.int. at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T GChild2::f.int. at .*: a > 30.*(\n|\r\n|\r)" }
 // { dg-output "GChild2: 207(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Base.: 1(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Child0.: 1(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1::f at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Child1::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.Child1.: 11(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild1::f at .*: a > 6.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T GChild1::f.int. at .*: a > 6.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.GChild1.: 101(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function GChild2::f at .*: a > 30.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T Base::f.int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual T GChild2::f.int. at .*: a > 30.*(\n|\r\n|\r)" }
 // { dg-output "fooBase.GChild2.: 201(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func3.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func3.C
@@ -25,6 +25,6 @@ int main()
   foo(c);
 
 }
-// { dg-output "contract violation in function Base<int>::f at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Child1<int>::f at .*: a > 3.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base<int>::f at .*: i > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function char Base<T>::f.int. .with T = int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function char Child1<T>::f.int. .with T = int. at .*: a > 3.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function char Base<T>::f.int. .with T = int. at .*: i > 4.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/callerside-checks/callerside-checks-all.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/callerside-checks/callerside-checks-all.C
@@ -34,19 +34,19 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output "contract violation in function f at .*: a > 2.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function f at .*: a > 2.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function f at .*: r > 2.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function f at .*: r > 2.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function S::f at .*: a > 3.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function S::f at .*: a > 3.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function S::f at .*: r > 3.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function S::f at .*: r > 3.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::f at .*: a > 4.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::f at .*: a > 4.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::f at .*: r > 4.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::f at .*: r > 4.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::tf at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::tf<int> at .*: a > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::tf<int> at .*: r > 5.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function TS<int>::tf at .*: r > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: a > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: a > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: r > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: r > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int S::f.int, int. at .*: a > 3.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int S::f.int, int. at .*: a > 3.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int S::f.int, int. at .*: r > 3.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int S::f.int, int. at .*: r > 3.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::f.int, T. .with T = int. at .*: a > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::f.int, T. .with T = int. at .*: a > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::f.int, T. .with T = int. at .*: r > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::f.int, T. .with T = int. at .*: r > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::tf.int, U. .with U = int; T = int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::tf.int, U. .with U = int; T = int. at .*: a > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::tf.int, U. .with U = int; T = int. at .*: r > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int TS<T>::tf.int, U. .with U = int; T = int. at .*: r > 5.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
@@ -13,11 +13,11 @@ int main(int, char**)
 
   foo (1);
 }
-// { dg-output "contract violation in function foo at .*5: i > 3.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int foo.int. at .*5: i > 3.*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 
-// { dg-output "contract violation in function foo at .*7: i > 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int foo.int. at .*7: i > 5.*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: assert, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 
-// { dg-output "contract violation in function foo at .*5: r > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int foo.int. at .*5: r > 4.*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception.C
@@ -17,5 +17,5 @@ int main(int, char**)
   f();
 }
 
-// { dg-output "contract violation in function f at .*: check.15..*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function void f.. at .*: check.15..*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: evaluation_exception: threw an instance of .int., terminating: no.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-friend1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-friend1.C
@@ -30,7 +30,7 @@ int main(int, char**) {
   return 0;
 }
 
-// { dg-output "contract violation in function fn0 at .*.C:7: .*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function X::fns0 at .*.C:9: .*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function X::fns1 at .*.C:10: .*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function X::fns2 at .*.C:11: .*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function void fn0.X. at .*.C:7: .*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function static void X::fns0.X. at .*.C:9: .*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function static void X::fns1.X. at .*.C:10: .*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function static void X::fns2.X. at .*.C:11: .*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
@@ -304,144 +304,144 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output {contract violation in function body<int> at .*:9: a > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int body.int. .with T = int. at .*:9: a > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-2(\n|\r\n|\r)} }
-// { dg-output {contract violation in function body<double> at .*:17: a > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int body.int. .with T = double. at .*:17: a > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-3(\n|\r\n|\r)} }
-// { dg-output {contract violation in function none<int> at .*:25: a > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int none.int. .with T = int. at .*:25: a > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
-// { dg-output {contract violation in function none<double> at .*:32: a > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int none.int. .with T = double. at .*:32: a > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-101(\n|\r\n|\r)} }
-// { dg-output {contract violation in function arg0<int> at .*:39: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int arg0.T. .with T = int. at .*:39: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-9(\n|\r\n|\r)} }
-// { dg-output {contract violation in function arg0<double> at .*:46: t > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int arg0.T. .with T = double. at .*:46: t > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {11(\n|\r\n|\r)} }
-// { dg-output {contract violation in function arg1<int> at .*:53: a > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int arg1.int, T. .with T = int. at .*:53: a > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function arg1<int> at .*:54: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int arg1.int, T. .with T = int. at .*:54: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-3(\n|\r\n|\r)} }
-// { dg-output {contract violation in function arg1<double> at .*:61: a > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int arg1.int, T. .with T = double. at .*:61: a > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function arg1<double> at .*:62: t > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int arg1.int, T. .with T = double. at .*:62: t > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {14(\n|\r\n|\r)} }
-// { dg-output {contract violation in function ret<int> at .*:69: a > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function T ret.int. .with T = int. at .*:69: a > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
-// { dg-output {contract violation in function ret<double> at .*:76: a > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function T ret.int. .with T = double. at .*:76: a > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {3(\n|\r\n|\r)} }
-// { dg-output {contract violation in function ret<double> at .*:76: a > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function T ret.int. .with T = double. at .*:76: a > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {3.300000(\n|\r\n|\r)} }
-// { dg-output {contract violation in function g1<int> at .*:83: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int g1.T. .with T = int. at .*:83: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-1(\n|\r\n|\r)} }
 // { dg-output {-1(\n|\r\n|\r)} }
-// { dg-output {contract violation in function g2<int> at .*:97: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int g2.T. .with T = int. at .*:97: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {-1(\n|\r\n|\r)} }
-// { dg-output {contract violation in function g2<double> at .*:107: t < 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int g2.T. .with T = double. at .*:107: t < 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {1(\n|\r\n|\r)} }
-// { dg-output {contract violation in function g2<char> at .*:114: t < 'c'(\n|\r\n|\r)} }
+// { dg-output {contract violation in function int g2.T. .with T = char. at .*:114: t < 'c'(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {100(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G3<double, double>::f at .*:124: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<T, S>::f.T, S. .with T = double; S = double. at .*:124: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G3<double, double>::f at .*:125: s > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<T, S>::f.T, S. .with T = double; S = double. at .*:125: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G3<int, int>::f at .*:134: t > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = int. at .*:134: t > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G3<int, int>::f at .*:134: s > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = int. at .*:134: s > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G3<int, double>::f at .*:147: t > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = double. at .*:147: t > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G3<int, double>::f at .*:148: s > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = double. at .*:148: s > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 full int double(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G3<char, char>::f at .*:124: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<T, S>::f.T, S. .with T = char; S = char. at .*:124: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G3<char, char>::f at .*:125: s > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<T, S>::f.T, S. .with T = char; S = char. at .*:125: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 general T S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G3<int, char>::f at .*:134: t > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = char. at .*:134: t > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G3<int, char>::f at .*:134: s > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G3<int, S>::f.int, S. .with S = char. at .*:134: s > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G3 partial int S(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }
 // { dg-output {G3 full int C(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G4<int, int>::G4 at .*:173: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<T, S>::G4.T, S. .with T = int; S = int. at .*:173: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G4<int, int>::G4 at .*:174: s > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<T, S>::G4.T, S. .with T = int; S = int. at .*:174: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G4 general T S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G4<int, int>::G4 at .*:175: x > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<T, S>::G4.T, S. .with T = int; S = int. at .*:175: x > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G4 full double double(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G4<double, char>::G4 at .*:206: a > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<T, S>::G4.T, S. .with T = double; S = char. at .*:206: a > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G4<double, char>::G4 at .*:207: b > 'b'(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<T, S>::G4.T, S. .with T = double; S = char. at .*:207: b > 'b'(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G4 full double char(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G4<double, char>::G4 at .*:208: x > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<T, S>::G4.T, S. .with T = double; S = char. at .*:208: x > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G4<char, int>::G4 at .*:187: t > 'c'(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<char, S>::G4.char, S. .with S = int. at .*:187: t > 'c'(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G4<char, int>::G4 at .*:188: s > 3(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<char, S>::G4.char, S. .with S = int. at .*:188: s > 3(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G4 partial char S(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G4<char, int>::G4 at .*:189: x2 > 3(\n|\r\n|\r)} }
+// { dg-output {contract violation in function G4<char, S>::G4.char, S. .with S = int. at .*:189: x2 > 3(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<int, int>::f<int> at .*:220: t > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = int; T = int; S = int. at .*:220: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<int, int>::f<int> at .*:221: s > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = int; T = int; S = int. at .*:221: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<int, int>::f<int> at .*:222: r > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G5<int, int>::f<double> at .*:220: t > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<int, int>::f<double> at .*:221: s > 0(\n|\r\n|\r)} }
-// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<int, int>::f<double> at .*:222: r > 0(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = int; T = int; S = int. at .*:222: r > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G5<char, int>::f<int> at .*:233: x > 'z'(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = double; T = int; S = int. at .*:220: t > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<char, int>::f<int> at .*:234: y > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = double; T = int; S = int. at .*:221: s > 0(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<char, int>::f<int> at .*:235: z > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = double; T = int; S = int. at .*:222: r > 0(\n|\r\n|\r)} }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
+// { dg-output {G5 gen T S, f gen R(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<char, S>::f.char, S, R. .with R = int; S = int. at .*:233: x > 'z'(\n|\r\n|\r)} }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
+// { dg-output {contract violation in function void G5<char, S>::f.char, S, R. .with R = int; S = int. at .*:234: y > 1(\n|\r\n|\r)} }
+// { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
+// { dg-output {contract violation in function void G5<char, S>::f.char, S, R. .with R = int; S = int. at .*:235: z > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G5 partial char S, f gen R(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G5<char, int>::f<double> at .*:233: x > 'z'(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<char, S>::f.char, S, R. .with R = double; S = int. at .*:233: x > 'z'(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<char, int>::f<double> at .*:234: y > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<char, S>::f.char, S, R. .with R = double; S = int. at .*:234: y > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<char, int>::f<double> at .*:235: z > 1(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<char, S>::f.char, S, R. .with R = double; S = int. at .*:235: z > 1(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G5 partial char S, f gen R(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G5<double, double>::f<int> at .*:244: a > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = int; T = double; S = double. at .*:244: a > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<double, double>::f<int> at .*:245: b > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = int; T = double; S = double. at .*:245: b > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<double, double>::f<int> at .*:246: c > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = int; T = double; S = double. at .*:246: c > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G5 full double double, f gen R(\n|\r\n|\r)} }
-// { dg-output {contract violation in function G5<double, double>::f<double> at .*:244: a > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = double; T = double; S = double. at .*:244: a > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<double, double>::f<double> at .*:245: b > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = double; T = double; S = double. at .*:245: b > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
-// { dg-output {contract violation in function G5<double, double>::f<double> at .*:246: c > 2(\n|\r\n|\r)} }
+// { dg-output {contract violation in function void G5<T, S>::f.T, S, P. .with P = double; T = double; S = double. at .*:246: c > 2(\n|\r\n|\r)} }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.(\n|\r\n|\r)" }
 // { dg-output {G5 full double double, f gen R(\n|\r\n|\r)} }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/definition-checks/contract-assert-no-def-check.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/definition-checks/contract-assert-no-def-check.C
@@ -22,4 +22,4 @@ int main(int, char**)
   foo(1);
   return 0;
 }
-// { dg-output "contract violation in function foo at .*: i > 4.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function void foo.int. at .*: i > 4.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/definition-checks/virtual-func-no-def-check2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/definition-checks/virtual-func-no-def-check2.C
@@ -27,5 +27,5 @@ int main(int, char**)
 
   return 0;
 }
-// { dg-output "contract violation in function Base::f at .*: a > 14.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function Base::f at .*: r > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: a > 14.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function virtual int Base::f.int. at .*: r > 2.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/noexcept-observe4.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/noexcept-observe4.C
@@ -11,5 +11,5 @@ int main(int, char**)
   return 0;
 }
 
-// { dg-output "contract violation in function f at .*: a > 2.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function f at .*: r > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: a > 2.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: r > 2.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/semantic-observe.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/semantic-observe.C
@@ -13,9 +13,9 @@ int main(int, char**)
   f(5);
   f(0,0);
 }
-// { dg-output "contract violation in function f at .*: r < 5.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: r < 5.*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: post, semantic: observe, mode: predicate_false, terminating: no.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function f at .*: i > 0.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: i > 0.*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: pre, semantic: observe, mode: predicate_false, terminating: no.*(\n|\r\n|\r)" }
-// { dg-output "contract violation in function f at .*: j > 0.*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function int f.int, int. at .*: j > 0.*(\n|\r\n|\r)" }
 // { dg-output ".assertion_kind: assert, semantic: observe, mode: predicate_false, terminating: no.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/src-loc-0.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/src-loc-0.C
@@ -1,0 +1,18 @@
+// { dg-do run }
+// { dg-options "-std=c++26 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe " }
+
+// Test source location without including <source_location>
+
+int
+foo (int x)
+  pre ( x > 10 )
+{
+  return x - 9;
+}
+
+int main ()
+{
+  foo (9);
+}
+
+// { dg-output "contract violation in function int foo.int. at .*:8: x > 10.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/src-loc-1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/src-loc-1.C
@@ -1,0 +1,18 @@
+// { dg-do run }
+// { dg-options "-std=c++26 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe " }
+// Test source location with #include <source_location>
+#include <source_location>
+
+int
+foo (int x)
+  pre ( x > 10 )
+{
+  return x - 9;
+}
+
+int main ()
+{
+  foo (9);
+}
+
+// { dg-output "contract violation in function int foo.int. at .*:8: x > 10.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/src-loc-2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/src-loc-2.C
@@ -1,0 +1,20 @@
+// { dg-do run }
+// { dg-options "-std=c++26 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe " }
+
+// Test source location with a late inclusion of <source_location>
+
+int
+foo (int x)
+  pre ( x > 10 )
+{
+  return x - 9;
+}
+
+#include <source_location>
+
+int main ()
+{
+  foo (9);
+}
+
+// { dg-output "contract violation in function int foo.int. at .*:8: x > 10.*(\n|\r\n|\r)" }

--- a/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh.cc
@@ -38,4 +38,4 @@ int main()
   f(0);
   VERIFY(custom_called);
 }
-// { dg-output "contract violation in function f at .*(\n|\r\n|\r)" }
+// { dg-output "contract violation in function void f.int. at .*(\n|\r\n|\r)" }


### PR DESCRIPTION
Another patch in the cleanup and prep for upstreaming camp.  This one does some re-factoring so that we can use common code to build source_location::__impls + some other tidies.  

-------

1. If the user has included <source_location> pick up the declarations from there, if not then build a layout-compatible internal type.

2. factor out the building of a source location impl in cp-gimplify.

3. Use the cp-gimplify source location builder instead of our local one.

4. Some tidies in the context of the private local source locaion impl.

5. instead of using wrapper or outlined function decls to print out the function names.. work back to the wrapped or host functions and use the decl from that.

6. updates to the testsuite for (5).

added some tests that we get the same results with or without including <source_location>


