### PR TITLE
libstdc++, contracts: Fix some fails on Darwin.

### DIFF
--- a/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation5.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/handle_assert_contract_violation5.cc
@@ -13,7 +13,8 @@
 // with this library; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
-// Check that a case when neither ASSERT_USES_CONTRACTS nor NDEBUG are defined behaves correctly.
+// Check that a case when neither ASSERT_USES_CONTRACTS nor NDEBUG are defined
+// behaves correctly (i.e. falls back to the libc assert).
 // Semantic chosen is a non terminating one.
 // { dg-options "-g0 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 // { dg-do run { target c++2a } }
@@ -23,12 +24,10 @@
 #include <cassert>
 #include <csignal>
 
-
 void my_term(int)
 {
   std::exit(0);
 }
-
 
 int main()
 {
@@ -39,5 +38,9 @@ int main()
   // We should not get here
   return 1;
 }
-// { dg-output "main.*: Assertion .*i == 4.* failed.*" }
 
+// Since we are now seeing the output of the libc 'assert' macro, this will
+// (in general) depend on the OS/libc being tested.
+
+// { dg-output "int main.*: Assertion .*i == 4.* failed.*" { target { ! *-*-darwin* } }  }
+// { dg-output "Assertion failed: .i == 4., function main," { target *-*-darwin*  }  }

--- a/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh2.cc
+++ b/libstdc++-v3/testsuite/18_support/contracts/invoke_default_cvh2.cc
@@ -56,15 +56,17 @@ void handle_contract_violation(const std::contracts::contract_violation& v)
   custom_called = true;
 }
 
-
 void f(int i) pre (i>10) {};
 
 int main()
 {
+  auto save_buf = std::cerr.rdbuf();
   checking_buf buf;
   std::cerr.rdbuf(&buf);
 
   f(0);
-  VERIFY(!buf.written);
+  std::cerr.rdbuf(save_buf);
+  VERIFY(buf.written == 0);
+  return 0;
 }
 


### PR DESCRIPTION
This one picks up some cases where we were not portable(enough) and one where Linux's forgiving attitude to out of lifetime things .. means a problem can go unnoticed -- the benefit of testing on more than one platform.   A re-check on Linux would be in order too.

-----

In one test we fall back to the libc 'assert' and the output from this is different got Darwin's libc, from Linux.

The cerr stream will be flushed when main() returns; which means it needs a valid buffer - so save and restore this across the tests.

