### PR TITLE
c++, contracts: Revise feature test macros for P2900.

### DIFF
--- a/gcc/c-family/c-cppbuiltin.cc
+++ b/gcc/c-family/c-cppbuiltin.cc
@@ -1102,9 +1102,14 @@ c_cpp_builtins (cpp_reader *pfile)
 	cpp_define (pfile, "__cpp_concepts=202002L");
       if (flag_contracts)
 	{
-	  cpp_define (pfile, "__cpp_contracts=201906L");
-	  cpp_define (pfile, "__cpp_contracts_literal_semantics=201906L");
-	  cpp_define (pfile, "__cpp_contracts_roles=201906L");
+	  if (flag_contracts_nonattr)
+	    cpp_define (pfile, "__cpp_contracts=202502L");
+	  else
+	    {
+	      cpp_define (pfile, "__cpp_contracts=201906L");
+	      cpp_define (pfile, "__cpp_contracts_literal_semantics=201906L");
+	      cpp_define (pfile, "__cpp_contracts_roles=201906L");
+	    }
 	}
       if (flag_modules)
 	/* The std-defined value is 201907L, but I don't think we can

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification.C
@@ -11,9 +11,7 @@
 // { dg-do compile }
 
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
 
 int gi = 7;
 int &gri = gi;

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification_const.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification_const.C
@@ -11,9 +11,7 @@
 // { dg-do compile }
 
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
 
 int gi = 7;
 int &gri = gi;

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification_const_mutable.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification_const_mutable.C
@@ -11,9 +11,7 @@
 // { dg-do compile }
 
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
 
 int gi = 7;
 int &gri = gi;
@@ -82,7 +80,7 @@ void template_related_tests()
   perfect_forward(ci);
   perfect_forward((const int&&) ci);
   perfect_forward2(666);
-// { dg-error {increment of read-only location} "" { target *-*-* } 67 }
+// { dg-error {increment of read-only location} "" { target *-*-* } 65 }
   S2 s;
   const S2 cs;
   s.perfect_forward();

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification_mutable.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification_mutable.C
@@ -11,9 +11,7 @@
 // { dg-do compile }
 
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
 
 int gi = 7;
 int &gri = gi;

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-run.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-run.C
@@ -23,9 +23,7 @@
 		if ((asserts && !violation) || (!(asserts) && violation)) __builtin_abort(); \
 	} \
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
 
 void handle_contract_violation(const std::contracts::contract_violation &violation) {
   std::cerr << "custom std::handle_contract_violation called:"

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert.C
@@ -10,9 +10,7 @@
 // { dg-do compile }
 // { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr" }
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
 
 int main()
 {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert_err.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert_err.C
@@ -12,10 +12,7 @@
 
 // { dg-prune-output "not declared" }
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
-
+static_assert (__cpp_contracts >= 202502L);
 
 contract_assert f(); // { dg-error "expected unqualified-id before .contract_assert." }
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts1.C
@@ -3,9 +3,8 @@
 // { dg-do compile }
 // { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr" }
 
-static_assert (__cpp_contracts >= 201906);
-static_assert (__cpp_contracts_literal_semantics >= 201906);
-static_assert (__cpp_contracts_roles >= 201906);
+static_assert (__cpp_contracts >= 202502L);
+
 int f(int);
 int g1(int a) pre(f(a) > a)
 {


### PR DESCRIPTION
fly-by cleanup...

-----

Remove the cxx2a additions and bump the contracts feature test to 202502.

