### PR TITLE
removing unused location info struct

### DIFF
--- a/libstdc++-v3/include/std/contracts
+++ b/libstdc++-v3/include/std/contracts
@@ -43,11 +43,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 namespace contracts
 {
   // From D3290R3
-  struct __location_info{
-    std::source_location _M_source_location;
-    explicit __location_info(std::source_location __location)
-    : _M_source_location(__location){}
-  };
 
   [[noreturn]] void handle_enforced_contract_violation(
       const char*,


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
