### PR TITLE
Copy and remap clean

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -832,8 +832,8 @@ finish_contract_attribute (tree identifier, tree contract)
      TODO: I'm not sure this is strictly necessary. It's going to be marked as
      such by a subroutine of cplus_decl_attributes. */
   tree condition = CONTRACT_CONDITION (contract);
-  if (TREE_CODE (condition) == DEFERRED_PARSE
-      || value_dependent_expression_p (condition))
+  if (TREE_CODE (condition) != DEFERRED_PARSE
+      && value_dependent_expression_p (condition))
     ATTR_IS_DEPENDENT (attribute) = true;
 
   return attribute;
@@ -1037,7 +1037,6 @@ remap_contract (tree src, tree dst, tree contract, bool duplicate_p)
   int src_num_artificial_args = num_artificial_parms_for (src);
   int dst_num_artificial_args = num_artificial_parms_for (dst);
 
-
   for (tree sp = DECL_ARGUMENTS (src), dp = DECL_ARGUMENTS (dst);
        sp || dp;
        sp = DECL_CHAIN (sp), dp = DECL_CHAIN (dp))
@@ -1077,6 +1076,7 @@ remap_contract (tree src, tree dst, tree contract, bool duplicate_p)
 	}
 
     }
+
   if (!do_remap)
     return;
 
@@ -3190,16 +3190,10 @@ maybe_apply_function_contracts (tree fndecl)
 }
 
 /* Returns a copy of SOURCE contracts where any references to SOURCE's
-   PARM_DECLs have been rewritten to the corresponding PARM_DECL in DEST. If
-   remap_result is true, result identifier is also re-mapped.
-   C++20 version used this function to remap contracts on virtual functions
-   from base class to derived class. In such a case postcondition identifier
-   wasn't remapped. Caller side wrapper functions need to remap the result
-   identifier.
-   If remap_post is false, postconditions are dropped from the destination.  */
+   PARM_DECLs have been rewritten to the corresponding PARM_DECL in DEST.  */
 
 tree
-copy_and_remap_contracts (tree dest, tree source, bool remap_result = true,
+copy_and_remap_contracts (tree dest, tree source,
 			  contract_match_kind remap_kind = cmk_all )
 {
   tree last = NULL_TREE, contract_attrs = NULL_TREE;
@@ -3220,12 +3214,14 @@ copy_and_remap_contracts (tree dest, tree source, bool remap_result = true,
       remap_contract (source, dest, CONTRACT_STATEMENT (c),
 		      /*duplicate_p=*/true);
 
-      if (remap_result
-	  && (TREE_CODE (CONTRACT_STATEMENT (c)) == POSTCONDITION_STMT))
+      if (TREE_CODE (CONTRACT_STATEMENT (c)) == POSTCONDITION_STMT)
 	{
 	  tree oldvar = POSTCONDITION_IDENTIFIER (CONTRACT_STATEMENT (c));
-	  if (oldvar)
+	  if (oldvar && oldvar!=error_mark_node)
+	    {
+	      tree type = copy_node (oldvar);
 	      DECL_CONTEXT (oldvar) = dest;
+	    }
 	}
 
       CONTRACT_COMMENT (CONTRACT_STATEMENT (c))
@@ -3518,10 +3514,8 @@ cxx2a_check_redecl_contract (tree newdecl, tree olddecl)
       if (contract_any_deferred_p (new_contracts))
 	copy_deferred_contracts(newdecl, olddecl);
       else
-	set_decl_contracts (olddecl,
-			  copy_and_remap_contracts (olddecl, newdecl,
-						    /*remap_result*/true,
-						    cmk_all));
+	set_decl_contracts (
+	    olddecl, copy_and_remap_contracts (olddecl, newdecl, cmk_all));
 
     }
 }
@@ -3568,7 +3562,6 @@ void update_contract_arguments(tree srcdecl, tree destdecl)
 	  DECL_ARGUMENTS (destdecl) = DECL_ARGUMENTS (srcdecl);
 	  set_decl_contracts (destdecl,
 			      copy_and_remap_contracts (destdecl, srcdecl,
-							/*remap_result*/true,
 							cmk_all));
 	  DECL_ARGUMENTS (destdecl) = tmp_arguments;
 	}
@@ -3590,8 +3583,7 @@ void update_contract_arguments(tree srcdecl, tree destdecl)
       else
       	set_decl_contracts (srcdecl,
       			    copy_and_remap_contracts (srcdecl, destdecl,
-            						    /*remap_result*/true,
-            						    cmk_all));
+						      cmk_all));
     }
 
   /* For deferred contracts, we currently copy the tokens from the redeclaration
@@ -3610,7 +3602,6 @@ void update_contract_arguments(tree srcdecl, tree destdecl)
       DECL_ARGUMENTS (destdecl) = DECL_ARGUMENTS (srcdecl);
       set_decl_contracts (destdecl,
 			  copy_and_remap_contracts (destdecl, srcdecl,
-						    /*remap_result*/true,
 						    cmk_all));
       DECL_ARGUMENTS (destdecl) = tmp_arguments;
     }
@@ -3699,8 +3690,7 @@ define_contract_wrapper_func (const tree& fndecl, const tree& wrapdecl, void*)
 
   /* FIXME: Maybe we should check if fndecl is still dependent?  */
 
-  /* FIXME: We should not really have any.  */
-  remove_contract_attributes (wrapdecl);
+  gcc_checking_assert(!DECL_CONTRACTS (wrapdecl));
   bool is_virtual = DECL_IOBJ_MEMBER_FUNCTION_P (fndecl)
 		    && DECL_VIRTUAL_P (fndecl);
   /* We check postconditions on virtual function calls or if postcondition
@@ -3715,8 +3705,7 @@ define_contract_wrapper_func (const tree& fndecl, const tree& wrapdecl, void*)
      when the wrapper is around a clone.  */
   set_decl_contracts( wrapdecl,
 		      copy_and_remap_contracts (wrapdecl, DECL_ORIGIN (fndecl),
-				       /*remap_result*/true,
-				       check_post? cmk_all : cmk_pre));
+						check_post? cmk_all : cmk_pre));
 
   start_preparsed_function (wrapdecl, /*DECL_ATTRIBUTES*/NULL_TREE,
 			    SF_DEFAULT | SF_PRE_PARSED);

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1037,6 +1037,7 @@ remap_contract (tree src, tree dst, tree contract, bool duplicate_p)
   int src_num_artificial_args = num_artificial_parms_for (src);
   int dst_num_artificial_args = num_artificial_parms_for (dst);
 
+
   for (tree sp = DECL_ARGUMENTS (src), dp = DECL_ARGUMENTS (dst);
        sp || dp;
        sp = DECL_CHAIN (sp), dp = DECL_CHAIN (dp))

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -359,7 +359,7 @@ extern bool diagnose_misapplied_contracts	(tree);
 extern tree finish_contract_attribute		(tree, tree);
 extern tree invalidate_contract			(tree);
 extern bool all_attributes_are_contracts_p	(tree);
-extern tree copy_and_remap_contracts		(tree, tree, bool, contract_match_kind);
+extern tree copy_and_remap_contracts		(tree, tree, contract_match_kind);
 extern void start_function_contracts		(tree);
 extern void maybe_apply_function_contracts	(tree);
 extern void finish_function_contracts		(tree);

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -31822,9 +31822,13 @@ void cp_parser_late_contract_condition (cp_parser *parser,
   cp_expr parsed_condition = cp_parser_conditional_expression (parser);
   /* Commit to changes.  */
   update_late_contract (contract, result, parsed_condition);
-  /* Leave our temporary scope for the postcondition result.  */
   if (r_ident)
     --processing_template_decl;
+
+  /* Rebuild the postcondition since we didn't do it in grokfndecl. */
+  rebuild_postconditions(fn);
+
+  /* Leave our temporary scope for the postcondition result.  */
   processing_postcondition = old_pc;
   should_constify_contract = old_const;
   gcc_checking_assert (scope_chain && scope_chain->bindings
@@ -31899,9 +31903,7 @@ cp_parser_inherited_contract_base (cp_parser *parser, tree fndecl,
     /* We're inheriting basefn's contracts; create a copy of them but
      * replace references to their parms to our parms.  */
 
-    base_contracts = copy_and_remap_contracts (fndecl, base_fn,
-					       /* remap_result */false,
-					       remap_kind);
+    base_contracts = copy_and_remap_contracts (fndecl, base_fn, remap_kind);
   }
   // todo warn on empty contracts ?
   return base_contracts;

--- a/gcc/cp/search.cc
+++ b/gcc/cp/search.cc
@@ -2196,7 +2196,6 @@ check_final_overrider (tree overrider, tree basefn)
 	set_decl_contracts( overrider,
 			    copy_and_remap_contracts (overrider,
 						      basefn,
-						      /*remap_result*/false,
 						      cmk_all));
       }
     else if (DECL_HAS_CONTRACTS_P (basefn) && DECL_HAS_CONTRACTS_P (overrider))
@@ -2257,10 +2256,8 @@ check_override_contracts (tree fndecl)
 	{
 	  /* We're inheriting basefn's contracts; create a copy of them but
 	   * replace references to their parms to our parms.  */
-	  tree base_contracts = copy_and_remap_contracts (
-	      fndecl, basefn,
-	      /* remap_result */false,
-	      cmk_all);
+	  tree base_contracts = copy_and_remap_contracts (fndecl, basefn,
+							  cmk_all);
 	  tree contracts = chainon (DECL_CONTRACTS (fndecl), base_contracts);
 
 	  set_decl_contracts (fndecl, contracts);

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P3653-virtual-func/inherited.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P3653-virtual-func/inherited.C
@@ -63,8 +63,8 @@ struct Base3
 
 struct Child0 : Base1
 {
-  virtual int f1(const int i) pre inherited (Base1) pre(checkC());
-  virtual int f2(const int i) post inherited (Base1){ return 1;}
+  virtual int f1(const int i) pre inherited (Base1) pre(checkC()) post(r: r>0);
+  virtual int f2(const int i) post inherited (Base1) post(r: r>0){ return 1;}
 };
 
 struct Child1 : Base1, private Base2, protected Base3

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification2.C
@@ -1,0 +1,86 @@
+// check that we do not get unused warnings for contract check function parameters
+// { dg-do compile }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce   -O -fdump-tree-all" }
+
+struct S{
+  S(){};
+  S(const S&){}
+  ~S(){};
+  int x = 0;
+};
+
+int i = 3;
+int *pi = &i;
+int *pi2 = &i;
+
+
+void f1() pre(i++) {} // { dg-error "increment of read-only location" }
+void f2() pre((*pi)++) {};
+void f3() pre(pi2++) {} // { dg-error "increment of read-only location" }
+
+int a[2] = {1, 2};
+auto [x, y] = a;
+auto& [xr, yr] = a;
+
+void f4() pre(x++) {} // { dg-error "increment of read-only location" }
+void f5() pre(xr++) {}; // { dg-error "increment of read-only location" }
+
+void f7(int x) pre([](int& i)
+	      {
+		return true;
+	      }(x)){} // { dg-error "discards qualifiers" }
+// { dg-error {no match for call to} "" { target *-*-* } .-1 }
+
+
+int g = 0;
+struct X { bool m(); };
+struct Y {
+  int z = 0;
+  //, int* p, int& r, X x, X* px)
+
+  void f(int i)  pre (++g); // { dg-error "increment of read-only location" }
+  void f2(int i) pre (++i); // { dg-error "increment of read-only location" }
+  void f3(int* p) pre (++(*p)); // OK
+  void f4(int& r) pre (++r); // { dg-error "increment of read-only location" }
+  void f5(X x) pre (x.m()); // { dg-error " argument discards qualifiers" }
+  void f6(X* px) pre (px->m()) // OK
+
+  // TODO when lambdas are fixed
+ /*void f7 pre ([=,&i,*this] mutable
+	 {
+	    ++g;	// error: attempting to modify const lvalue
+	    ++i;	// error: attempting to modify const lvalue
+	    ++p;	// OK, refers to member of closure type
+	    ++r;	// OK, refers to non−reference member of closure type
+	    ++this->z; // OK, captured *this
+	    ++z;	// OK, captured *this
+	    int j = 17;
+	    [&]{
+	      int k = 34;
+	      ++i; // error: attempting to modify const lvalue
+	      ++j; // OK
+	      ++k; // OK
+	    }();
+	    return true;
+	 }())*/;
+
+  template <int N, int& R, int* P>
+  void tf1() pre(++N); 	// { dg-error "increment of read-only location" }
+  // { dg-error {lvalue required as increment operand} "" { target *-*-* } .-1 }
+
+  template <int N, int& R, int* P>
+  void tf2() pre(++R);	// { dg-error "increment of read-only location" }
+
+  template <int N, int& R, int* P>
+  void tf3() pre(++(*P)); // OK
+
+  int h1() post(r : ++r); // { dg-error "increment of read-only" }
+
+  // TODO when lambdas are fixed
+/*  int h2() post(r : [=]() mutable {
+			++r;	// OK, refers to member of closure type
+			return true;
+	    }());
+*/
+  int& k() post(r : ++r); // { dg-error "increment of read-only" }
+};

--- a/gcc/testsuite/g++.dg/contracts/cpp26/return_value.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/return_value.C
@@ -1,0 +1,140 @@
+// Various tests with non trivial return value identifier
+// in either derived class or base class.
+// { dg-do compile }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr" }
+
+
+struct NonTrivial{
+  NonTrivial(){};
+  NonTrivial(const NonTrivial&){}
+  ~NonTrivial(){};
+  int x = 0;
+};
+
+template<typename T>
+bool check(T t){
+  return true;
+}
+struct S{
+ NonTrivial f1(const NonTrivial i) post(r: i.x > 0 ) { return NonTrivial{};}
+
+ template <typename T>
+ NonTrivial f2(const T i) post(r: i.x > 0 ) { return NonTrivial{};}
+
+ auto f3(const NonTrivial i) post(r: i.x > 0 ) { return NonTrivial{};}
+
+ template <typename T>
+ T f4(const T i) post(r: i.x > 0 ) { return NonTrivial{};}
+
+ template <typename T>
+ auto f5(const T i) post(r: i.x > 0 ) { return i;}
+
+ template <typename T>
+ auto f6(const T i) post(r: check(i) ) { return i;}
+
+ auto f7(const NonTrivial i) post(r: check(r) ) { return i;}
+
+};
+
+template <typename U>
+struct S1
+{
+
+  struct S2
+  {
+    NonTrivial
+    f1 (const NonTrivial i) post(r: i.x > 0 )
+      { return NonTrivial
+	  {};
+      }
+
+      template <typename T>
+      NonTrivial
+      f2 (const T i) post(r: i.x > 0 )
+	{ return NonTrivial
+	    {};
+	}
+
+	auto
+	f3 (const NonTrivial i)
+	post(r: i.x > 0 )
+	  { return NonTrivial
+	      {};}
+
+	template <typename T>
+	T
+	f4 (const T i)
+	post(r: i.x > 0 )
+	  { return NonTrivial
+	      {};}
+
+	template <typename T>
+	auto
+	f5 (const T i)
+	post(r: i.x > 0 )
+	  { return i;}
+
+      };
+
+    NonTrivial
+    f1 (const NonTrivial i)
+    post(r: i.x > 0 )
+      { S2 s;
+	return s.f1(i);
+      }
+
+    template <typename T>
+    NonTrivial
+    f2 (const T i)
+    post(r: i.x > 0 )
+      { S2 s;
+	return s.f2(i);
+      }
+
+    auto
+    f3 (const NonTrivial i)
+    post(r: i.x > 0 )
+      { S2 s;
+	return s.f3(i);
+      }
+
+    template <typename T>
+    T
+    f4 (const T i)
+    post(r: i.x > 0 )
+      { S2 s;
+	return s.f4(i);
+      }
+
+    template <typename T>
+    auto
+    f5 (const T i)
+    post(r: i.x > 0 )
+      { S2 s;
+	return s.f5(i);
+      }
+
+  };
+
+
+int main()
+{
+  S s;
+  NonTrivial n;
+  s.f1(NonTrivial{});
+
+  s.f2(n);
+  s.f3(n);
+  s.f4(n);
+  s.f5(n);
+  s.f6(n);
+  s.f7(n);
+
+
+  S1<NonTrivial> s1;
+  s1.f1(n);
+  s1.f2(n);
+  s1.f3(n);
+  s1.f4(n);
+  s1.f5(n);
+}


### PR DESCRIPTION
- removing unnecessary (and wrong) flag from copy_and_remap 
- removing making of deferred parse contract as dependent expression
- fixing an issue with postconditions with return value identifier
- adding a test that was not added by mistake before