### PR TITLE
c++, contracts: Check ignored semantic in get_contract_semantic().

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2248,13 +2248,13 @@ get_evaluation_semantic (tree contract)
       return CES_OBSERVE;
     }
 
-  /* Used when building P2900R10 contract_violation object. Note that we do not
-     build such objects unless we are going to use them - so that we should not
-     get asked for 'ignore' or 'quick'.  */
+  /* The p2900 cases.  */
   switch (semantic)
     {
       default:
 	gcc_unreachable ();
+      case CCS_IGNORE:
+	return CES_IGNORE;
       case CCS_OBSERVE:
 	return CES_OBSERVE;
       case CCS_ENFORCE:

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-ignored.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-ignored.C
@@ -1,0 +1,23 @@
+// { dg-do run }
+// { dg-options "-std=c++26 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=ignore" }
+
+#include <contracts>
+
+int f(int i, int j = 1)
+  pre (i > 0)
+  post (r: r < 5)
+{
+  contract_assert ( j > 0);
+  return i;
+}
+
+int main(int, char**)
+{
+  f (0,0);
+}
+
+void
+handle_contract_violation (const std::contracts::contract_violation &)
+{
+  __builtin_abort ();
+}


### PR DESCRIPTION
fixes an ICE (assertion triggered) when using `-fcontract-evaluation-semantic=ignore`

