### PR TITLE
Contracts nonattr function specifiers

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -1156,16 +1156,13 @@ contract_attribute_valid_p (tree attribute)
   return contract_valid_p (TREE_VALUE (TREE_VALUE (attribute)));
 }
 
-/* Compare the contract conditions of OLD_ATTR and NEW_ATTR. Returns false
-   if the conditions are equivalent, and true otherwise.  */
+/* Compare the contract conditions of OLD_CONTRACT and NEW_CONTRACT.
+   Returns false if the conditions are equivalent, and true otherwise.  */
 
 static bool
-check_for_mismatched_contracts (tree old_attr, tree new_attr,
-			       contract_matching_context ctx)
+mismatched_contracts_p (tree old_contract, tree new_contract,
+			contract_matching_context ctx)
 {
-  tree old_contract = CONTRACT_STATEMENT (old_attr);
-  tree new_contract = CONTRACT_STATEMENT (new_attr);
-
   /* Different kinds of contracts do not match.  */
   if (TREE_CODE (old_contract) != TREE_CODE (new_contract))
     {
@@ -1216,7 +1213,7 @@ check_for_mismatched_contracts (tree old_attr, tree new_attr,
    if the contracts match, and false if they differ.  */
 
 bool
-match_contract_conditions (location_t oldloc, tree old_attrs,
+match_contract_attributes (location_t oldloc, tree old_attrs,
 			   location_t newloc, tree new_attrs,
 			   contract_matching_context ctx)
 {
@@ -1233,7 +1230,8 @@ match_contract_conditions (location_t oldloc, tree old_attrs,
 	  || !contract_attribute_valid_p (old_attrs))
 	return false;
 
-      if (check_for_mismatched_contracts (old_attrs, new_attrs, ctx))
+      if (mismatched_contracts_p (CONTRACT_STATEMENT (old_attrs),
+				  CONTRACT_STATEMENT (new_attrs), ctx))
 	return false;
       old_attrs = NEXT_CONTRACT_ATTR (old_attrs);
       new_attrs = NEXT_CONTRACT_ATTR (new_attrs);
@@ -1322,7 +1320,7 @@ match_deferred_contracts (tree fndecl)
 	 This means the diagnostic may claim override even in case oF
 	 re declarations.  */
       tree base = TREE_PURPOSE (pending);
-      match_contract_conditions (new_loc, new_contracts,
+      match_contract_attributes (new_loc, new_contracts,
 				 old_loc, old_contracts,
 				 base ? cmc_override : cmc_declaration);
     }
@@ -3420,7 +3418,7 @@ p2900_check_redecl_contract (tree newdecl, tree olddecl)
       location_t cont_end = get_contract_end_loc (new_contracts);
       cont_end = make_location (new_loc, new_loc, cont_end);
       /* We have two sets - they should match or we issue a diagnostic.  */
-      match_contract_conditions (rd.note_loc, rd.original_contracts, cont_end,
+      match_contract_attributes (rd.note_loc, rd.original_contracts, cont_end,
 				 new_contracts, cmc_declaration);
     }
 
@@ -3485,7 +3483,7 @@ cxx2a_check_redecl_contract (tree newdecl, tree olddecl)
 	     doesn't.  */
 	  }
       else
-	match_contract_conditions (old_loc, old_contracts, new_loc,
+	match_contract_attributes (old_loc, old_contracts, new_loc,
 				   new_contracts, cmc_declaration);
 
       return;

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -256,15 +256,15 @@ enum contract_match_kind
 
 /* True iff the FUNCTION_DECL NODE currently has any contracts.  */
 #define DECL_HAS_CONTRACTS_P(NODE) \
-  (DECL_CONTRACTS (NODE) != NULL_TREE)
+  (DECL_CONTRACT_ATTRS (NODE) != NULL_TREE)
 
 /* For a FUNCTION_DECL of a guarded function, this points to a list of the pre
    and post contracts of the first decl of NODE in original order. */
-#define DECL_CONTRACTS(NODE) \
+#define DECL_CONTRACT_ATTRS(NODE) \
   (find_contract (DECL_ATTRIBUTES (NODE)))
 
 /* The next contract (if any) after this one in an attribute list.  */
-#define CONTRACT_CHAIN(NODE) \
+#define NEXT_CONTRACT_ATTR(NODE) \
   (find_contract (TREE_CHAIN (NODE)))
 
 /* The wrapper of the original source location of a list of contracts.  */

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -256,7 +256,9 @@ enum contract_match_kind
 
 /* True iff the FUNCTION_DECL NODE currently has any contracts.  */
 #define DECL_HAS_CONTRACTS_P(NODE) \
-  (DECL_CONTRACT_ATTRS (NODE) != NULL_TREE)
+  ((flag_contracts_nonattr \
+    ? GET_FN_CONTRACT_SPECIFIERS (NODE) \
+    : DECL_CONTRACT_ATTRS (NODE)) != NULL_TREE)
 
 /* For a FUNCTION_DECL of a guarded function, this points to a list of the pre
    and post contracts of the first decl of NODE in original order. */
@@ -266,6 +268,14 @@ enum contract_match_kind
 /* The next contract (if any) after this one in an attribute list.  */
 #define NEXT_CONTRACT_ATTR(NODE) \
   (find_contract (TREE_CHAIN (NODE)))
+
+/* For a function decl, get the head of the contract_specifiers list.  */
+#define GET_FN_CONTRACT_SPECIFIERS(NODE) \
+  get_fn_contract_specifiers (NODE)
+
+/* For a function decl, get the head of the contract_specifiers list.  */
+#define SET_FN_CONTRACT_SPECIFIERS(NODE, LIST) \
+  set_fn_contract_specifiers ((NODE), (LIST))
 
 /* The wrapper of the original source location of a list of contracts.  */
 #define CONTRACT_SOURCE_LOCATION_WRAPPER(NODE) \
@@ -346,6 +356,11 @@ enum contract_match_kind
   (DECL_DECLARES_FUNCTION_P (NODE) && DECL_LANG_SPECIFIC (NODE) && \
    DECL_CONTRACT_WRAPPER (NODE))
 
+extern void set_fn_contract_specifiers		(tree, tree);
+extern void update_fn_contract_specifiers	(tree, tree);
+extern tree get_fn_contract_specifiers		(tree);
+extern void unset_fn_contract_specifiers	(tree);
+
 extern void maybe_update_postconditions		(tree);
 extern void rebuild_postconditions		(tree);
 extern bool check_postcondition_result		(tree, tree, location_t);
@@ -359,7 +374,7 @@ extern bool diagnose_misapplied_contracts	(tree);
 extern tree finish_contract_attribute		(tree, tree);
 extern tree invalidate_contract			(tree);
 extern bool all_attributes_are_contracts_p	(tree);
-extern tree copy_and_remap_contracts		(tree, tree, contract_match_kind);
+extern tree copy_and_remap_contracts		(tree, tree, contract_match_kind remap_kind = cmk_all);
 extern void start_function_contracts		(tree);
 extern void maybe_apply_function_contracts	(tree);
 extern void finish_function_contracts		(tree);

--- a/gcc/cp/cp-gimplify.cc
+++ b/gcc/cp/cp-gimplify.cc
@@ -1548,7 +1548,8 @@ cp_fold_function (tree fndecl)
    */
   tree contracts = remove_contract_attributes (fndecl);
   cp_walk_tree (&DECL_SAVED_TREE (fndecl), cp_fold_r, &data, NULL);
-  set_contract_attributes (fndecl, contracts);
+  if (contracts)
+    set_contract_attributes (fndecl, contracts);
 
   /* This is merely an optimization: if FNDECL has no i-e expressions,
      we'll not save c_f_d, and we can safely say that FNDECL will not

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -6828,7 +6828,8 @@ struct cp_declarator {
       /* The trailing requires-clause, if any.  */
       tree requires_clause;
       /* The function-contract-specifier-seq, if any.  */
-      tree contracts;
+      tree contract_specifiers;
+      /* The position of the opening brace for a function definition.  */
       location_t parens_loc;
     } function;
     /* For arrays.  */

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -9179,8 +9179,13 @@ find_contract (tree attrs)
 inline void
 set_decl_contracts (tree decl, tree contract_attrs)
 {
-  remove_contract_attributes (decl);
-  DECL_ATTRIBUTES (decl) = chainon (DECL_ATTRIBUTES (decl), contract_attrs);
+  if (flag_contracts_nonattr)
+    set_fn_contract_specifiers (decl, contract_attrs);
+  else
+    {
+      remove_contract_attributes (decl);
+      DECL_ATTRIBUTES (decl) = chainon (DECL_ATTRIBUTES (decl), contract_attrs);
+    }
 }
 
 /* Returns the computed semantic of the node.  */

--- a/gcc/cp/decl.cc
+++ b/gcc/cp/decl.cc
@@ -3389,6 +3389,9 @@ duplicate_decls (tree newdecl, tree olddecl, bool hiding, bool was_hidden)
   if (flag_concepts)
     remove_constraints (newdecl);
 
+  if (flag_contracts_nonattr)
+    unset_fn_contract_specifiers (newdecl);
+
   /* And similarly for any module tracking data.  */
   if (modules_p ())
     remove_defining_module (newdecl);
@@ -6040,10 +6043,9 @@ start_decl (const cp_declarator *declarator,
       && !processing_template_decl
       && DECL_RESULT (decl)
       && is_auto (TREE_TYPE (DECL_RESULT (decl))))
-    for (tree contract = DECL_CONTRACT_ATTRS (decl); contract;
-	 contract = NEXT_CONTRACT_ATTR (contract))
-      if (POSTCONDITION_P (CONTRACT_STATEMENT (contract))
-	  && POSTCONDITION_IDENTIFIER (CONTRACT_STATEMENT (contract)))
+    for (tree ca = GET_FN_CONTRACT_SPECIFIERS (decl); ca; ca = TREE_CHAIN (ca))
+      if (POSTCONDITION_P (CONTRACT_STATEMENT (ca))
+	  && POSTCONDITION_IDENTIFIER (CONTRACT_STATEMENT (ca)))
 	{
 	  error_at (DECL_SOURCE_LOCATION (decl),
 		    "postconditions with deduced result name types must only"
@@ -11485,6 +11487,7 @@ grokfndecl (tree ctype,
 	    int template_count,
 	    tree in_namespace,
 	    tree* attrlist,
+	    tree contract_specifiers,
 	    location_t location)
 {
   tree decl;
@@ -11923,9 +11926,14 @@ grokfndecl (tree ctype,
 	}
     }
 
+
   /* Caller will do the rest of this.  */
   if (check < 0)
-    return decl;
+    {
+      if (decl && decl != error_mark_node && contract_specifiers)
+	SET_FN_CONTRACT_SPECIFIERS (decl, contract_specifiers);
+      return decl;
+    }
 
   if (ctype != NULL_TREE)
     grokclassfn (ctype, decl, flags);
@@ -11956,7 +11964,16 @@ grokfndecl (tree ctype,
       *attrlist = NULL_TREE;
     }
 
-  if (DECL_HAS_CONTRACTS_P (decl))
+  /* Update now we have a decl and maybe know the return type.  */
+  if (contract_specifiers)
+    {
+      tree t = decl;
+      if (TREE_CODE (decl) == TEMPLATE_DECL)
+	t = DECL_TEMPLATE_RESULT (decl);
+      SET_FN_CONTRACT_SPECIFIERS (t, contract_specifiers);
+      rebuild_postconditions (t);
+    }
+  else if (DECL_CONTRACT_ATTRS (decl))
     rebuild_postconditions (decl);
 
   /* Check main's type after attributes have been applied.  */
@@ -13297,6 +13314,7 @@ grokdeclarator (const cp_declarator *declarator,
   tree raises = NULL_TREE;
   int template_count = 0;
   tree returned_attrs = NULL_TREE;
+  tree contract_specifiers = NULL_TREE;
   tree parms = NULL_TREE;
   const cp_declarator *id_declarator;
   /* The unqualified name of the declarator; either an
@@ -14345,7 +14363,7 @@ grokdeclarator (const cp_declarator *declarator,
 
       inner_declarator = declarator->declarator;
 
-      /* Check that contracts aren't misapplied.  */
+      /* Check that contract attributes aren't misapplied.  */
       if (tree contract_attr = find_contract (declarator->std_attributes))
 	if (declarator->kind != cdk_function
 	    || innermost_code != cdk_function)
@@ -14889,10 +14907,10 @@ grokdeclarator (const cp_declarator *declarator,
 
 	    /* Actually apply the contract attributes to the declaration.  */
 	    if (flag_contracts_nonattr)
-	      returned_attrs
-		= chainon (returned_attrs,
-			   declarator->u.function.contract_specifiers);
-	    /* Allow mixing std-attribute style and p2900 syntax.  */
+	      contract_specifiers
+		= attr_chainon (contract_specifiers,
+				declarator->u.function.contract_specifiers);
+
 	    for (tree *p = &attrs; *p;)
 	      {
 		tree l = *p;
@@ -15869,10 +15887,15 @@ grokdeclarator (const cp_declarator *declarator,
 			       is_xobj_member_function, sfk,
 			       funcdef_flag, late_return_type_p,
 			       template_count, in_namespace,
-			       attrlist, id_loc);
-            decl = set_virt_specifiers (decl, virt_specifiers);
+			       attrlist, contract_specifiers, id_loc);
+	    decl = set_virt_specifiers (decl, virt_specifiers);
 	    if (decl == NULL_TREE)
 	      return error_mark_node;
+	    if (0 && flag_contracts_nonattr && contract_specifiers)
+	      {
+		SET_FN_CONTRACT_SPECIFIERS (decl, contract_specifiers);
+		rebuild_postconditions (decl);
+	      }
 #if 0
 	    /* This clobbers the attrs stored in `decl' from `attrlist'.  */
 	    /* The decl and setting of decl_attr is also turned off.  */
@@ -16198,7 +16221,7 @@ grokdeclarator (const cp_declarator *declarator,
 
 	decl = grokfndecl (ctype, type, original_name, parms, unqualified_id,
 			   declspecs,
-                           reqs, virtualp, flags, memfn_quals, rqual, raises,
+			   reqs, virtualp, flags, memfn_quals, rqual, raises,
 			   1, friendp,
 			   publicp,
 			   inlinep | (2 * constexpr_p) | (4 * concept_p)
@@ -16208,9 +16231,14 @@ grokdeclarator (const cp_declarator *declarator,
 			   funcdef_flag,
 			   late_return_type_p,
 			   template_count, in_namespace, attrlist,
-			   id_loc);
+			   contract_specifiers, id_loc);
 	if (decl == NULL_TREE)
 	  return error_mark_node;
+	if (0 && flag_contracts_nonattr && contract_specifiers)
+	  {
+	    SET_FN_CONTRACT_SPECIFIERS (decl, contract_specifiers);
+	    rebuild_postconditions (decl);
+	  }
 
 	if (explicitp == 2)
 	  DECL_NONCONVERTING_P (decl) = 1;

--- a/gcc/cp/decl.cc
+++ b/gcc/cp/decl.cc
@@ -1864,7 +1864,7 @@ duplicate_decls (tree newdecl, tree olddecl, bool hiding, bool was_hidden)
 	  /* Contracts are currently in the attribute tree. We do not handle
 	     them here because we assume built-ins don't have contracts.  */
 	  gcc_assert(!flag_contracts ||
-		     ! (DECL_CONTRACTS(newdecl) || DECL_CONTRACTS(olddecl)));
+		     ! (DECL_CONTRACT_ATTRS(newdecl) || DECL_CONTRACT_ATTRS(olddecl)));
 
 	  tree type = TREE_TYPE (newdecl);
 	  tree attribs = (*targetm.merge_type_attributes)
@@ -6040,8 +6040,8 @@ start_decl (const cp_declarator *declarator,
       && !processing_template_decl
       && DECL_RESULT (decl)
       && is_auto (TREE_TYPE (DECL_RESULT (decl))))
-    for (tree contract = DECL_CONTRACTS (decl); contract;
-	 contract = CONTRACT_CHAIN (contract))
+    for (tree contract = DECL_CONTRACT_ATTRS (decl); contract;
+	 contract = NEXT_CONTRACT_ATTR (contract))
       if (POSTCONDITION_P (CONTRACT_STATEMENT (contract))
 	  && POSTCONDITION_IDENTIFIER (CONTRACT_STATEMENT (contract)))
 	{

--- a/gcc/cp/decl.cc
+++ b/gcc/cp/decl.cc
@@ -14889,7 +14889,9 @@ grokdeclarator (const cp_declarator *declarator,
 
 	    /* Actually apply the contract attributes to the declaration.  */
 	    if (flag_contracts_nonattr)
-	      returned_attrs = chainon (returned_attrs, declarator->u.function.contracts);
+	      returned_attrs
+		= chainon (returned_attrs,
+			   declarator->u.function.contract_specifiers);
 	    /* Allow mixing std-attribute style and p2900 syntax.  */
 	    for (tree *p = &attrs; *p;)
 	      {

--- a/gcc/cp/decl2.cc
+++ b/gcc/cp/decl2.cc
@@ -2357,7 +2357,7 @@ comdat_linkage (tree decl)
   if (flag_weak)
     {
       make_decl_one_only (decl, cxx_comdat_group (decl));
-      if (HAVE_COMDAT_GROUP && flag_contracts && DECL_CONTRACTS (decl))
+      if (HAVE_COMDAT_GROUP && flag_contracts && DECL_CONTRACT_ATTRS (decl))
 	{
 	  symtab_node *n = symtab_node::get (decl);
 	  if (tree pre = DECL_PRE_FN (decl))

--- a/gcc/cp/decl2.cc
+++ b/gcc/cp/decl2.cc
@@ -2357,7 +2357,9 @@ comdat_linkage (tree decl)
   if (flag_weak)
     {
       make_decl_one_only (decl, cxx_comdat_group (decl));
-      if (HAVE_COMDAT_GROUP && flag_contracts && DECL_CONTRACT_ATTRS (decl))
+      if (HAVE_COMDAT_GROUP
+	  && flag_contracts
+	  && (DECL_CONTRACT_ATTRS (decl) || GET_FN_CONTRACT_SPECIFIERS (decl)))
 	{
 	  symtab_node *n = symtab_node::get (decl);
 	  if (tree pre = DECL_PRE_FN (decl))

--- a/gcc/cp/module.cc
+++ b/gcc/cp/module.cc
@@ -11103,9 +11103,10 @@ trees_out::fn_parms_init (tree fn)
   if (!streaming_p ())
     {
       /* We must walk contract attrs so the dependency graph is complete. */
-      for (tree contract = DECL_CONTRACT_ATTRS (fn);
-	  contract;
-	  contract = NEXT_CONTRACT_ATTR (contract))
+      tree contract = flag_contracts_nonattr
+		      ? GET_FN_CONTRACT_SPECIFIERS (fn)
+		      : DECL_CONTRACT_ATTRS (fn);
+      for (; contract; contract = NEXT_CONTRACT_ATTR (contract))
 	tree_node (contract);
     }
 

--- a/gcc/cp/module.cc
+++ b/gcc/cp/module.cc
@@ -11103,9 +11103,9 @@ trees_out::fn_parms_init (tree fn)
   if (!streaming_p ())
     {
       /* We must walk contract attrs so the dependency graph is complete. */
-      for (tree contract = DECL_CONTRACTS (fn);
+      for (tree contract = DECL_CONTRACT_ATTRS (fn);
 	  contract;
-	  contract = CONTRACT_CHAIN (contract))
+	  contract = NEXT_CONTRACT_ATTR (contract))
 	tree_node (contract);
     }
 

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -32481,7 +32481,7 @@ void cp_parser_late_contracts (cp_parser *parser,
 {
 
   tree new_contracts = NULL_TREE;
-  for (tree a = DECL_CONTRACTS (fndecl); a; a = CONTRACT_CHAIN (a))
+  for (tree a = DECL_CONTRACT_ATTRS (fndecl); a; a = NEXT_CONTRACT_ATTR (a))
     {
 	tree contract = TREE_VALUE(TREE_VALUE (a));
 

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -2021,7 +2021,7 @@ make_call_declarator (cp_declarator *target,
 		      tree exception_specification,
 		      tree late_return_type,
 		      tree requires_clause,
-		      tree contracts,
+		      tree contract_specifiers,
 		      tree std_attrs,
 		      location_t parens_loc)
 {
@@ -2037,7 +2037,7 @@ make_call_declarator (cp_declarator *target,
   declarator->u.function.exception_specification = exception_specification;
   declarator->u.function.late_return_type = late_return_type;
   declarator->u.function.requires_clause = requires_clause;
-  declarator->u.function.contracts = contracts;
+  declarator->u.function.contract_specifiers = contract_specifiers;
   declarator->u.function.parens_loc = parens_loc;
   if (target)
     {
@@ -12592,9 +12592,9 @@ cp_parser_lambda_declarator_opt (cp_parser* parser, tree lambda_expr,
       return_type = cp_parser_trailing_type_id (parser);
     }
 
-  tree contracts = NULL_TREE;
+  tree contract_specifiers = NULL_TREE;
   if (flag_contracts_nonattr)
-    contracts = cp_parser_function_contract_specifier_seq (parser);
+    contract_specifiers = cp_parser_function_contract_specifier_seq (parser);
 
   /* Also allow GNU attributes at the very end of the declaration, the usual
      place for GNU attributes.  */
@@ -12662,7 +12662,7 @@ cp_parser_lambda_declarator_opt (cp_parser* parser, tree lambda_expr,
 				       exception_spec,
 				       return_type,
 				       trailing_requires_clause,
-				       contracts,
+				       contract_specifiers,
 				       std_attrs,
 				       UNKNOWN_LOCATION);
 
@@ -25358,9 +25358,10 @@ cp_parser_direct_declarator (cp_parser* parser,
 		  /* Parse the virt-specifier-seq.  */
 		  virt_specifiers = cp_parser_virt_specifier_seq_opt (parser);
 
-		  tree contracts = NULL_TREE;
+		  tree contract_specifiers = NULL_TREE;
 		  if (flag_contracts_nonattr)
-		    contracts = cp_parser_function_contract_specifier_seq (parser);
+		    contract_specifiers
+		      = cp_parser_function_contract_specifier_seq (parser);
 		  /* ??? should we accept std-attr contracts here too? */
 
 		  location_t parens_loc = make_location (parens_start,
@@ -25376,7 +25377,7 @@ cp_parser_direct_declarator (cp_parser* parser,
 						     exception_specification,
 						     late_return,
 						     requires_clause,
-						     contracts,
+						     contract_specifiers,
 						     std_attrs,
 						     parens_loc);
 		  declarator->attributes = gnu_attrs;
@@ -32711,8 +32712,7 @@ cp_parser_contract_assert (cp_parser *parser, cp_token *token)
     attributed-identifier :
 
    Return void_list_node if the current token doesn't start a
-   contract specifier.
-*/
+   contract specifier.  */
 
 static tree
 cp_parser_function_contract_specifier (cp_parser *parser)
@@ -32728,11 +32728,8 @@ cp_parser_function_contract_specifier (cp_parser *parser)
   if (!contract_name
       || !(is_attribute_p ("pre", contract_name)
 	   || is_attribute_p ("post", contract_name)))
-    /* If we don't have a valid contract start, return a marker.  */
-    return void_list_node;
-
-  // this does not currently handle attribute-specifier-seqopt for
-  // a natural contract syntax.
+    /* If we don't have a valid contract start, we are done.  */
+    return NULL_TREE;
 
   cp_lexer_consume_token (parser->lexer);
   location_t loc = token->location;
@@ -32901,16 +32898,15 @@ cp_parser_function_contract_specifier (cp_parser *parser)
   if (contract != error_mark_node)
     set_contract_const (contract, should_constify);
 
-  return finish_contract_attribute (contract_name, contract);
+  return contract;
 }
 
 /* Parse a natural syntax contract specifier seq. Returns a list of
-preconditions and postconditions in an attribute tree. Only handles
-pre and post conditions - contract_assert is handled separately.
+   preconditions and postconditions in an attribute tree.
 
-    function-contract-specifier-seq :
-      function-contract-specifier function-contract-specifier-seq
-*/
+  function-contract-specifier-seq :
+    function-contract-specifier function-contract-specifier-seq.  */
+
 static tree
 cp_parser_function_contract_specifier_seq (cp_parser *parser)
 {
@@ -32918,16 +32914,21 @@ cp_parser_function_contract_specifier_seq (cp_parser *parser)
 
   while (true)
     {
-      tree attr_spec = cp_parser_function_contract_specifier (parser);
+      tree contract_spec = cp_parser_function_contract_specifier (parser);
 
-      // If there are no more contracts, bail.
-      if (attr_spec == void_list_node)
+      /* If there are no more contracts, done.  */
+      if (contract_spec == NULL_TREE)
 	break;
 
-      // Ignore any erroneous contracts and attempt to continue parsing.
-      if (attr_spec == error_mark_node)
+      /* Ignore any erroneous contracts and attempt to continue parsing.  */
+      if (contract_spec == error_mark_node)
 	continue;
 
+      /* For now, turn this into an attribute.  */
+      tree contract_name = TREE_CODE (contract_spec) == PRECONDITION_STMT
+			   ? get_identifier ("pre")
+			   : get_identifier ("post");
+      tree attr_spec = finish_contract_attribute (contract_name, contract_spec);
       /* Arrange to build the list in the correct order.  */
       if (attr_specs)
 	attr_specs = attr_chainon (attr_spec, attr_specs);

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -3222,7 +3222,10 @@ check_explicit_specialization (tree declarator,
 		}
 	      decl = register_specialization (tmpl, gen_tmpl, targs,
 					      is_friend, 0);
-	      remove_contract_attributes (result);
+	      if (flag_contracts_nonattr)
+		set_fn_contract_specifiers (result, NULL_TREE);
+	      else
+		remove_contract_attributes (result);
 	      return decl;
 	    }
 
@@ -3318,7 +3321,12 @@ check_explicit_specialization (tree declarator,
 	  /* If this is a specialization, splice any contracts that may have
 	     been inherited from the template, removing them.  */
 	  if (decl != error_mark_node && DECL_TEMPLATE_SPECIALIZATION (decl))
-	    remove_contract_attributes (decl);
+	    {
+	      if (flag_contracts_nonattr)
+		set_fn_contract_specifiers (decl, NULL_TREE);
+	      else
+		remove_contract_attributes (decl);
+	    }
 
 	  /* A 'structor should already have clones.  */
 	  gcc_assert (decl == error_mark_node
@@ -12249,7 +12257,10 @@ tsubst_contract_attributes (tree attributes, tree decl, tree args,
       TREE_CHAIN (nc) = subst_contract_list;
       subst_contract_list = nc;
   }
-  set_contract_attributes(decl, nreverse(subst_contract_list));
+  if (flag_contracts_nonattr)
+    set_fn_contract_specifiers (decl, nreverse(subst_contract_list));
+  else
+    set_contract_attributes (decl, nreverse(subst_contract_list));
 }
 
 /* Instantiate a single dependent attribute T (a TREE_LIST), and return either
@@ -15180,6 +15191,12 @@ tsubst_function_decl (tree t, tree args, tsubst_flags_t complain,
   if (tree ci = get_constraints (t))
     set_constraints (r, ci);
 
+  /* copy_decl () does not know about contract specifiers.  NOTE these are not
+     substituted at this point.  */
+  if (tree ctrct = get_fn_contract_specifiers (t))
+    set_fn_contract_specifiers (r, ctrct);
+
+  /* The parms have now been substituted, check for incorrect const cases.  */
   check_postconditions_in_redecl (t,r);
 
   if (DECL_FRIEND_CONTEXT (t))
@@ -27721,19 +27738,20 @@ regenerate_decl_from_template (tree decl, tree tmpl, tree args)
 	    DECL_CONTEXT (t) = decl;
 	}
 
-      if (DECL_CONTRACT_ATTRS (decl))
+      if (tree attr = flag_contracts_nonattr
+		      ? GET_FN_CONTRACT_SPECIFIERS (decl)
+		      : DECL_CONTRACT_ATTRS (decl))
 	{
-	  tree attributes = DECL_ATTRIBUTES (decl);
 	  /* If we're regenerating a specialization, the contracts will have
 	     been copied from the most general template. Replace those with
 	     the ones from the actual specialization.  */
 	  tree tmpl = DECL_TI_TEMPLATE (decl);
 	  if (DECL_TEMPLATE_SPECIALIZATION (tmpl))
-	    {
-	      attributes = DECL_ATTRIBUTES(code_pattern);
-	    }
+	    attr = flag_contracts_nonattr
+		   ? GET_FN_CONTRACT_SPECIFIERS (code_pattern)
+		   : DECL_CONTRACT_ATTRS (code_pattern);
 
-	  tsubst_contract_attributes (attributes, decl, args,
+	  tsubst_contract_attributes (attr, decl, args,
 				      tf_warning_or_error, code_pattern);
 	}
 

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -12242,7 +12242,7 @@ tsubst_contract_attributes (tree attributes, tree decl, tree args,
 {
   tree subst_contract_list = NULL_TREE;
   for (tree attr = find_contract (attributes); attr;
-      attr = CONTRACT_CHAIN (attr))
+      attr = NEXT_CONTRACT_ATTR (attr))
   {
       tree nc = copy_node (attr);
       tsubst_contract_attribute (decl, nc, args, complain, in_decl);
@@ -27721,7 +27721,7 @@ regenerate_decl_from_template (tree decl, tree tmpl, tree args)
 	    DECL_CONTEXT (t) = decl;
 	}
 
-      if (DECL_CONTRACTS (decl))
+      if (DECL_CONTRACT_ATTRS (decl))
 	{
 	  tree attributes = DECL_ATTRIBUTES (decl);
 	  /* If we're regenerating a specialization, the contracts will have

--- a/gcc/cp/search.cc
+++ b/gcc/cp/search.cc
@@ -2206,7 +2206,10 @@ check_final_overrider (tree overrider, tree basefn)
 
 	   Note that OVERRIDER's contracts will have been fully parsed at the
 	   point the deferred match is run.  */
-	defer_guarded_contract_match (overrider, basefn, DECL_CONTRACT_ATTRS (basefn));
+	tree base_ct = flag_contracts_nonattr
+			? GET_FN_CONTRACT_SPECIFIERS (basefn)
+			: DECL_CONTRACT_ATTRS (basefn);
+	defer_guarded_contract_match (overrider, basefn, base_ct);
       }
   }
   if (DECL_FINAL_P (basefn))
@@ -2258,9 +2261,15 @@ check_override_contracts (tree fndecl)
 	   * replace references to their parms to our parms.  */
 	  tree base_contracts = copy_and_remap_contracts (fndecl, basefn,
 							  cmk_all);
-	  tree contracts = chainon (DECL_CONTRACT_ATTRS (fndecl), base_contracts);
+	  tree fn_contracts = flag_contracts_nonattr
+			      ? GET_FN_CONTRACT_SPECIFIERS (fndecl)
+			      : DECL_CONTRACT_ATTRS (fndecl);
+	  tree contracts = chainon (fn_contracts, base_contracts);
 
-	  set_decl_contracts (fndecl, contracts);
+	  if (flag_contracts_nonattr)
+	    SET_FN_CONTRACT_SPECIFIERS (fndecl, contracts);
+	  else
+	    set_decl_contracts (fndecl, contracts);
 
 	  if (suggest_explicit_contract)
 	    {

--- a/gcc/cp/search.cc
+++ b/gcc/cp/search.cc
@@ -2206,7 +2206,7 @@ check_final_overrider (tree overrider, tree basefn)
 
 	   Note that OVERRIDER's contracts will have been fully parsed at the
 	   point the deferred match is run.  */
-	defer_guarded_contract_match (overrider, basefn, DECL_CONTRACTS (basefn));
+	defer_guarded_contract_match (overrider, basefn, DECL_CONTRACT_ATTRS (basefn));
       }
   }
   if (DECL_FINAL_P (basefn))
@@ -2258,7 +2258,7 @@ check_override_contracts (tree fndecl)
 	   * replace references to their parms to our parms.  */
 	  tree base_contracts = copy_and_remap_contracts (fndecl, basefn,
 							  cmk_all);
-	  tree contracts = chainon (DECL_CONTRACTS (fndecl), base_contracts);
+	  tree contracts = chainon (DECL_CONTRACT_ATTRS (fndecl), base_contracts);
 
 	  set_decl_contracts (fndecl, contracts);
 


### PR DESCRIPTION
This is preparatory work, it does not particularly achieve (many) improvements at this stage (some reduction in iterating through DECL_ATTRIBUTE ()) .. but it is intended to allow us to handle function contract specifies separately from the function attributes, since they have different properties.  At this stage, we are still representing the specifiers as a list of "attributes" although the attribute name is academic now
