### PR TITLE
testsuite, c++, contracts: Clean up commandline options [NFC].

### DIFF
--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/contracts-multiple-inheritance2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/contracts-multiple-inheritance2.C
@@ -1,5 +1,5 @@
 // { dg-do compile }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 
 struct BaseA {
   virtual int fun(int n) pre ( n > 0 ) { return -n; }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/contracts-pre4.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/contracts-pre4.C
@@ -1,6 +1,6 @@
 // test that contracts on overriding functions are found correctly
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 
 struct Base
 {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual-base.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual-base.C
@@ -1,6 +1,6 @@
 // check that we do not a section type conflict with virtual bases or a duplicate symbol
 // { dg-do run }
-// { dg-options "-fcontracts -std=c++23 -fcontracts-nonattr -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr -fcontracts-on-virtual-functions=P2900R13" }
 
 int x = 9;
 struct Base

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual-func-nontrivial.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual-func-nontrivial.C
@@ -1,7 +1,7 @@
 // Test that non trivial types work ok with a contract wrapper for virtual
 // functions.
 // { dg-do compile }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -g3 -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -g3 -fcontracts-on-virtual-functions=P2900R13" }
 
 struct NonTrivial{
   NonTrivial(){};

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func.C
@@ -1,6 +1,6 @@
 // test that contracts on overriding functions are found correctly
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 #include <cstdio>
 
 struct Base

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func1.C
@@ -1,6 +1,6 @@
 // test that contracts on overriding functions are found correctly
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 
 #include <cstdio>
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func3.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func3.C
@@ -1,5 +1,5 @@
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-continuation-mode=on -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 template<typename T>
 struct Base
 {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func_err.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P2900R13-virtual-func/virtual_func_err.C
@@ -1,6 +1,6 @@
 // These tests cover various crashes found in development
 // { dg-do compile }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-continuation-mode=on -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 template<typename T>
 struct Base
 {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P3510-1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P3510-1.C
@@ -1,5 +1,5 @@
 // { dg-do run }
-// { dg-options "-fcontracts -fcontracts-nonattr -std=c++23" }
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr " }
 
 struct S{
   bool f() const { return true;}

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P3510-2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P3510-2.C
@@ -1,5 +1,5 @@
 // { dg-do compile }
-// { dg-options "-fcontracts -fcontracts-nonattr -std=c++23" }
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr " }
 
 struct S{
   bool f();

--- a/gcc/testsuite/g++.dg/contracts/cpp26/P3653-virtual-func/virtual_base.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/P3653-virtual-func/virtual_base.C
@@ -1,5 +1,5 @@
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=off -fcontracts-nonattr -fcontracts-on-virtual-functions=P3653 " }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce -fcontracts-on-virtual-functions=P3653 " }
 #include <cassert>
 
 struct contract

--- a/gcc/testsuite/g++.dg/contracts/cpp26/constification2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/constification2.C
@@ -1,6 +1,6 @@
 // check that we do not get unused warnings for contract check function parameters
 // { dg-do compile }
-// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce   -O -fdump-tree-all" }
+// { dg-options "-std=c++2b -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=enforce -O " }
 
 struct S{
   S(){};

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-run.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-assert-run.C
@@ -8,7 +8,7 @@
 //   ensure that an invalid contract role 'invalid' errors
 //   ensure that a missing colon after contract role errors
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-continuation-mode=on" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 #include <iostream>
 #include <contracts>
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract-violation-noexcept.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract-violation-noexcept.C
@@ -1,6 +1,6 @@
 // test that the default contract violation handler can't throw
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-evaluation-semantic=observe -fcontracts-nonattr " }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe " }
 
 #include <iostream>
 #include <exception>

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contract_violation.C
@@ -1,6 +1,6 @@
 // test that contracts on overriding functions are found correctly
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr " }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe " }
 
 int foo(const int i) pre( i > 3) post (r: r > 4){
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception.C
@@ -1,5 +1,5 @@
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-continuation-mode=on" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 
 bool check(int i){
   if (i > 10)

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-friend1.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-friend1.C
@@ -1,6 +1,6 @@
 // ensure contracts on friend declarations are a complete class context
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 
 
 struct X {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-nested-class2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-nested-class2.C
@@ -1,5 +1,5 @@
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fcontracts-nonattr" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe" }
 
 void gfn3(int n) pre (n > 0 );
 

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-tmpl-spec2.C
@@ -1,6 +1,6 @@
 // basic test to ensure contracts work for class and member specializations
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontract-continuation-mode=on -fsigned-char -fcontracts-nonattr" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fsigned-char" }
 #include <cstdio>
 
 // template specializations can have differing contracts

--- a/gcc/testsuite/g++.dg/contracts/cpp26/definition-checks/virtual-func-no-def-check2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/definition-checks/virtual-func-no-def-check2.C
@@ -1,7 +1,7 @@
 // check that an invocation of a virtual function through the base class checks
 // the base class contracts when definition side contracts are turned off
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontracts-nonattr-definition-check=off -fcontract-continuation-mode=on -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontracts-nonattr-definition-check=off -fcontract-evaluation-semantic=observe -fcontracts-on-virtual-functions=P2900R13" }
 
 struct Base
 {

--- a/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param.C
@@ -1,6 +1,6 @@
 // check that we do not ICE with an empty nontrivial parameter
 // { dg-do run }
-// { dg-options "-std=c++2b -fcontracts -std=c++23 -fcontracts-nonattr " }
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr " }
 
 struct NTClass {
   NTClass(){};

--- a/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param2.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/empty-nt-param2.C
@@ -1,6 +1,6 @@
 // check that we do not ICE with an empty nontrivial parameter
 // { dg-do compile }
-// { dg-options "-std=c++2b -fcontracts -std=c++23 -fcontracts-nonattr " }
+// { dg-options "-std=c++23 -fcontracts -fcontracts-nonattr " }
 struct NTClass {
   NTClass(){};
   ~NTClass(){};


### PR DESCRIPTION
This replaces any uses of the to-be-deprecated attribute format options and instead uses the current C++26 versions.  Small tidy-ups in unused options and duplicated std specs.

