### PR TITLE
c++, contracts: Avoid unnecessary specifier map entries.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -3266,8 +3266,10 @@ update_fn_contract_specifiers (tree decl, tree list)
   rd.contract_specifiers = list;
 }
 
+/* When a decl is about to be removed, then we need to release its content and
+   then take it out of the map.  */
 void
-unset_fn_contract_specifiers (tree decl)
+remove_decl_with_fn_contracts_specifiers (tree decl)
 {
   if (contract_redecl *p = hash_map_safe_get (redeclared_contracts, decl))
     {
@@ -3275,6 +3277,19 @@ unset_fn_contract_specifiers (tree decl)
       p->original_contracts = NULL_TREE;
       p->pending_list = NULL_TREE;
       redeclared_contracts->remove (decl);
+    }
+}
+
+/* If this function has contract specifiers, then remove them, but leave the
+   function registered.  */
+void
+remove_fn_contract_specifiers (tree decl)
+{
+  if (contract_redecl *p = hash_map_safe_get (redeclared_contracts, decl))
+    {
+      p->contract_specifiers = NULL_TREE;
+      p->original_contracts = NULL_TREE;
+      p->pending_list = NULL_TREE;
     }
 }
 
@@ -3287,7 +3302,6 @@ get_fn_contract_specifiers (tree decl)
     return p->contract_specifiers;
   return NULL_TREE;
 }
-
 
 /* A subroutine of duplicate_decls. Diagnose issues in the redeclaration of
    guarded functions.  */

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -370,7 +370,8 @@ extern tree view_as_const			(tree);
 extern void set_fn_contract_specifiers		(tree, tree);
 extern void update_fn_contract_specifiers	(tree, tree);
 extern tree get_fn_contract_specifiers		(tree);
-extern void unset_fn_contract_specifiers	(tree);
+extern void remove_decl_with_fn_contracts_specifiers (tree);
+extern void remove_fn_contract_specifiers	(tree);
 extern void update_contract_arguments		(tree, tree);
 
 extern void match_deferred_contracts		(tree);

--- a/gcc/cp/decl.cc
+++ b/gcc/cp/decl.cc
@@ -3391,7 +3391,8 @@ duplicate_decls (tree newdecl, tree olddecl, bool hiding, bool was_hidden)
     remove_constraints (newdecl);
 
   if (flag_contracts_nonattr)
-    unset_fn_contract_specifiers (newdecl);
+    /* Remove the specifiers, and then remove the decl from the lookup.  */
+    remove_decl_with_fn_contracts_specifiers (newdecl);
 
   /* And similarly for any module tracking data.  */
   if (modules_p ())

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -3224,7 +3224,7 @@ check_explicit_specialization (tree declarator,
 	      decl = register_specialization (tmpl, gen_tmpl, targs,
 					      is_friend, 0);
 	      if (flag_contracts_nonattr)
-		set_fn_contract_specifiers (result, NULL_TREE);
+		remove_fn_contract_specifiers (result);
 	      else
 		remove_contract_attributes (result);
 	      return decl;
@@ -3324,7 +3324,7 @@ check_explicit_specialization (tree declarator,
 	  if (decl != error_mark_node && DECL_TEMPLATE_SPECIALIZATION (decl))
 	    {
 	      if (flag_contracts_nonattr)
-		set_fn_contract_specifiers (decl, NULL_TREE);
+		remove_fn_contract_specifiers (decl);
 	      else
 		remove_contract_attributes (decl);
 	    }


### PR DESCRIPTION
When we have a specialisation, it might be given contract specifiers (depending on whether they are present on the template, as a side-effect of the instantiation process).  However, these added specifiers are then deleted - since the presence of (and spelling of) specifiers on specialisations is independent of the original template.

We were doing this by adding empty contracts to the specialisation. This has an unfortunate side-effect of adding decls to the specifier lookup map, even if the decl had no contracts already.  This can play badly with GC and hash collisions.

Solve this by adding an interface that only deletes specifiers on functions already registered.

This is subtely different from the case when we are about to ggc_delete a decl (in that case we actually also want to remove the decl from the map too).  So renamed that interface to say that it will remove the decl.

