### PR TITLE
c++, contracts: Default to inlined contract checks.

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1962,7 +1962,7 @@ C++ Joined RejectNegative Enum(p2900_semantic) Var(flag_contract_evaluation_sema
 -fcontract-evaluation-semantic=[ignore|observe|enforce|quick_enforce|noexcept_enforce|noexcept_observe]	Select the contract evaluation semantic (defaults to enforce).
 
 fcontract-checks-outlined
-C++ Var(flag_contract_checks_outlined) Init(1)
+C++ Var(flag_contract_checks_outlined) Init(0)
 -fcontract-checks-outlined	Build contract checks as an out-of-line function.
 
 fcontract-disable-optimized-checks

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/freefunc-noexcept-post.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/freefunc-noexcept-post.C
@@ -2,7 +2,7 @@
 // behaves as if the function exited via an exception.
 // This tests the behaviour of a pre condition on a member function
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined" }
 
 #include <contracts>
 #include <exception>

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/freefunc-noexcept-pre.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/freefunc-noexcept-pre.C
@@ -1,8 +1,8 @@
 // Throwing violation handler in a pre/post check on a noexcept function
 // behaves as if the function exited via an exception.
-// This tests the behaviour of a post condition on a member function
+// This tests the behaviour of a pre condition on a member function
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined" }
 
 #include <contracts>
 #include <exception>
@@ -23,24 +23,21 @@ void handle_contract_violation(const std::contracts::contract_violation& violati
   throw MyException{};
 }
 
-struct X
+void f(int x) noexcept pre(x>1)
 {
-    void f(const int x) noexcept post(x>1) {
-      try{
-       int i = 1;
-      }
-      catch(...) {
-      }
-    }
-};
+  try{
+   int i = 1;
+  }
+  catch(...) {
+  }
+}
 
 int main()
 {
   std::set_terminate (my_term);
   try
   {
-      X x;
-      x.f(-42);
+      f(-42);
   } catch (...) {
   }
   // We should not get here

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/func-noexcept-assert.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/func-noexcept-assert.C
@@ -1,7 +1,7 @@
 // Throwing violation handler in an assert check in a noexcept function
 // can be caught by the function.
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined" }
 
 #include <contracts>
 #include <exception>

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/memberfunc-noexcept-post.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/memberfunc-noexcept-post.C
@@ -1,8 +1,8 @@
 // Throwing violation handler in a pre/post check on a noexcept function
 // behaves as if the function exited via an exception.
-// This tests the behaviour of a post condition on a virtual member function
+// This tests the behaviour of a post condition on a member function
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined" }
 
 #include <contracts>
 #include <exception>
@@ -25,7 +25,7 @@ void handle_contract_violation(const std::contracts::contract_violation& violati
 
 struct X
 {
-    virtual void f(const int x) noexcept post(x>1){
+    void f(const int x) noexcept post(x>1) {
       try{
        int i = 1;
       }
@@ -45,4 +45,5 @@ int main()
   }
   // We should not get here
   return 1;
+
 }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/memberfunc-noexcept-pre.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/memberfunc-noexcept-pre.C
@@ -2,7 +2,7 @@
 // behaves as if the function exited via an exception.
 // This tests the behaviour of a pre condition on a member function
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined" }
 
 #include <contracts>
 #include <exception>

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/virtualfunc-noexcept-post.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/virtualfunc-noexcept-post.C
@@ -1,8 +1,8 @@
 // Throwing violation handler in a pre/post check on a noexcept function
 // behaves as if the function exited via an exception.
-// This tests the behaviour of a pre condition on a member function
+// This tests the behaviour of a post condition on a virtual member function
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined -fcontracts-on-virtual-functions=P2900R13" }
 
 #include <contracts>
 #include <exception>
@@ -23,24 +23,26 @@ void handle_contract_violation(const std::contracts::contract_violation& violati
   throw MyException{};
 }
 
-void f(int x) noexcept pre(x>1)
+struct X
 {
-  try{
-   int i = 1;
-  }
-  catch(...) {
-  }
-}
+    virtual void f(const int x) noexcept post(x>1){
+      try{
+       int i = 1;
+      }
+      catch(...) {
+      }
+    }
+};
 
 int main()
 {
   std::set_terminate (my_term);
   try
   {
-      f(-42);
+      X x;
+      x.f(-42);
   } catch (...) {
   }
   // We should not get here
   return 1;
-
 }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/virtualfunc-noexcept-pre.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/outline-checks/virtualfunc-noexcept-pre.C
@@ -2,7 +2,7 @@
 // behaves as if the function exited via an exception.
 // This tests the behaviour of a pre condition on a virtual member function
 // { dg-do run }
-// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fno-contract-checks-outlined -fcontracts-on-virtual-functions=P2900R13" }
+// { dg-options "-std=c++2a -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=observe -fcontract-checks-outlined -fcontracts-on-virtual-functions=P2900R13" }
 
 #include <contracts>
 #include <exception>


### PR DESCRIPTION

We still have the option to outline them with -fcontract-checks-outlined.

Switch the tests that were checking -fno-contract-checks-outlined to do the opposite.

