### PR TITLE
c++, contracts: Abstract interfaces to constexpr.

### DIFF
--- a/gcc/cp/constexpr.cc
+++ b/gcc/cp/constexpr.cc
@@ -10116,14 +10116,13 @@ cxx_eval_constant_expression (const constexpr_ctx *ctx, tree t,
     case PRECONDITION_STMT:
     case POSTCONDITION_STMT:
       {
-	contract_semantic semantic = get_contract_semantic (t);
-	if (semantic == CCS_IGNORE)
+	if (contract_ignored_p (t))
 	  break;
 
 	if (!cxx_eval_assert (ctx, CONTRACT_CONDITION (t),
 			      G_("contract predicate is false in "
 				 "constant expression"),
-			      EXPR_LOCATION (t), checked_contract_p (semantic),
+			      EXPR_LOCATION (t), contract_evaluated_p (t),
 			      non_constant_p, overflow_p))
 	  *non_constant_p = true;
 	r = void_node;

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -505,4 +505,19 @@ parm_used_in_post_p (const_tree decl)
   return ((TREE_CODE (decl) == PARM_DECL) && DECL_LANG_FLAG_4 (decl));
 }
 
+/* Will this contract be ignored.  */
+
+inline bool
+contract_ignored_p (const_tree contract)
+{
+  return (get_contract_semantic (contract) <= CCS_IGNORE); 
+}
+
+/* Will this contract be evaluated?  */
+
+inline bool
+contract_evaluated_p (const_tree contract)
+{
+  return (get_contract_semantic (contract) >= CCS_NEVER); 
+}
 #endif /* ! GCC_CP_CONTRACT_H */


### PR DESCRIPTION
We want to move to havong different representations of the contract semantic for C++26, since that wants values outside the range that can be accommodated in the cxx2a edition.  First part, abstract the interfaces to constexpr, so that they do not see the underlying source of data.

