### PR TITLE
c++, contracts: Rework  __builtin_contract_violation_type.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -409,9 +409,8 @@ set_postcondition_function (tree fndecl, tree post)
   orig_from_outlined->put (post, fndecl);
 }
 
-/* tree that holds the pseude source location type */
+/* tree that holds the internal representation source location _impl */
 static GTY(()) tree contracts_source_location_impl_type;
-static GTY(()) tree contracts_source_location_type;
 
 static tree
 get_orig_for_outlined (tree fndecl)
@@ -894,40 +893,6 @@ build_contract_violation (tree contract, bool is_const)
     return build_contract_violation_p2900 (contract, is_const);
 
   return build_contract_violation_cxx2a (contract);
-}
-
-static tree get_cxx2a_contract_violation_fields ();
-static tree get_p9600_contract_violation_fields ();
-
-static tree
-get_pseudo_contract_violation_type ()
-{
-  if (pseudo_contract_violation_type)
-    return pseudo_contract_violation_type;
-
-  tree fields;
-  if (flag_contracts_nonattr)
-    fields = get_p9600_contract_violation_fields ();
-  else
-    fields = get_cxx2a_contract_violation_fields ();
-
-  iloc_sentinel ils (input_location);
-  input_location = BUILTINS_LOCATION;
-  pseudo_contract_violation_type = make_class_type (RECORD_TYPE);
-  finish_builtin_struct (pseudo_contract_violation_type,
-			 "__pseudo_contract_violation", fields, NULL_TREE);
-  CLASSTYPE_AS_BASE (pseudo_contract_violation_type)
-    = pseudo_contract_violation_type;
-  DECL_CONTEXT (TYPE_NAME (pseudo_contract_violation_type))
-    = FROB_CONTEXT (global_namespace);
-//  TREE_PUBLIC (TYPE_NAME (pseudo_contract_violation_type)) = true;
-  CLASSTYPE_LITERAL_P (pseudo_contract_violation_type) = true;
-  CLASSTYPE_LAZY_COPY_CTOR (pseudo_contract_violation_type) = true;
-  xref_basetypes (pseudo_contract_violation_type, /*bases=*/NULL_TREE);
-  pseudo_contract_violation_type
-    = cp_build_qualified_type (pseudo_contract_violation_type,
-			       TYPE_QUAL_CONST);
-  return pseudo_contract_violation_type;
 }
 
 /* Add the contract statement CONTRACT to the current block if valid.  */
@@ -1577,7 +1542,7 @@ build_contract_violation_cxx2a (tree contract)
     default: gcc_unreachable ();
     }
 
-  /* Must match the type layout in get_pseudo_contract_violation_type.  */
+  /* Must match the type layout in builtin_contract_violation_type.  */
   tree ctor = build_constructor_va
     (init_list_type_node, 7,
      NULL_TREE, build_string_literal (loc.file),
@@ -1588,7 +1553,7 @@ build_contract_violation_cxx2a (tree contract)
      NULL_TREE, build_int_cst (uint_least32_type_node, loc.line),
      NULL_TREE, build_int_cst (signed_char_type_node, cmode));
 
-  ctor = finish_compound_literal (get_pseudo_contract_violation_type (),
+  ctor = finish_compound_literal (builtin_contract_violation_type,
 				  ctor, tf_none, fcl_c99);
   protected_set_expr_location (ctor, EXPR_LOCATION (contract));
   return ctor;
@@ -2230,12 +2195,24 @@ lookup_std_type (tree name_id)
    type.  */
 
 static tree
-get_contracts_source_location_impl_type (tree context)
+get_contracts_source_location_impl_type (tree context = NULL_TREE)
 {
   if (contracts_source_location_impl_type)
      return contracts_source_location_impl_type;
 
-  // first build the __impl layout equivalent type
+  /* First see if we have a declaration that we can use.  */
+  tree contracts_source_location_type
+    = lookup_std_type (get_identifier ("source_location"));
+
+  if (contracts_source_location_type
+      && contracts_source_location_type != error_mark_node
+      && TYPE_FIELDS (contracts_source_location_type))
+    {
+      contracts_source_location_impl_type = get_source_location_impl_type ();
+      return contracts_source_location_impl_type;
+    }
+
+  /* We do not, so build the __impl layout equivalent type
   /* Must match <source_location>:
      struct __impl
       {
@@ -2281,73 +2258,11 @@ get_contracts_source_location_impl_type (tree context)
   return contracts_source_location_impl_type;
 }
 
-/* We need a source_location type regardless of whether the user includes
-   <source_location>.
-   So, first look to see is we can find std::source_location (and the relevant
-   __impl type).  If that fails, then fall back to building a layout-compatible
-   internal type (__source_location).  */
-
 static tree
-get_contracts_source_location_type ()
+get_contracts_impl_ptr (location_t loc)
 {
-  if (contracts_source_location_type)
-    return contracts_source_location_type;
-
-  contracts_source_location_type
-    = lookup_std_type (get_identifier ("source_location"));
-
-  if (contracts_source_location_type
-      && contracts_source_location_type != error_mark_node
-      && TYPE_FIELDS (contracts_source_location_type))
-    {
-      contracts_source_location_impl_type = get_source_location_impl_type ();
-      return contracts_source_location_type;
-    }
-
-  /* Must match <source_location>:
-     struct source_location
-       {
-	 private:
-	    const __impl* _M_impl = nullptr;
-	};  */
-  iloc_sentinel ils (input_location);
-  input_location = BUILTINS_LOCATION;
-  contracts_source_location_type = make_class_type (RECORD_TYPE);
-
-  tree impl_type
-    = get_contracts_source_location_impl_type (contracts_source_location_type);
-  /* Only one field.  */
-  tree f_type = build_pointer_type (impl_type);
-  tree fields = build_decl (BUILTINS_LOCATION, FIELD_DECL,
-			    get_identifier ("_M_impl"), f_type);
-  finish_builtin_struct (contracts_source_location_type,
-			 "__source_location", fields, NULL_TREE);
-  CLASSTYPE_AS_BASE (contracts_source_location_type)
-    = contracts_source_location_type;
-  xref_basetypes (contracts_source_location_type, /*bases=*/NULL_TREE);
-  DECL_CONTEXT (TYPE_NAME (contracts_source_location_type))
-    = FROB_CONTEXT (global_namespace);
-  CLASSTYPE_LAZY_DEFAULT_CTOR (contracts_source_location_type) = true;
-  CLASSTYPE_LAZY_DESTRUCTOR (contracts_source_location_type) = true;
-  contracts_source_location_type
-    = cp_build_qualified_type (contracts_source_location_type,
-			       TYPE_QUAL_CONST);
-  return contracts_source_location_type;
-}
-
-/* Build a layout-compatible internal version of source location type
-   with location LOC.  */
-
-static tree
-build_contracts_source_location (location_t loc)
-{
-  /* Make sure we have the types.  */
-  tree s_type = get_contracts_source_location_type ();
-  gcc_checking_assert (TYPE_FIELDS (contracts_source_location_type));
-  gcc_checking_assert (TYPE_FIELDS (contracts_source_location_impl_type));
-
-  /* There is only one relevant field.  */
-  tree f = next_aggregate_field (TYPE_FIELDS (s_type));
+  if (!contracts_source_location_impl_type)
+    get_contracts_source_location_impl_type ();
 
   tree fndecl = current_function_decl;
   /* We might be an outlined function.  */
@@ -2361,15 +2276,8 @@ build_contracts_source_location (location_t loc)
   tree impl__
     = build_source_location_impl (loc, fndecl,
 				  contracts_source_location_impl_type);
-  impl__ = build_fold_addr_expr_with_type_loc (loc, impl__, TREE_TYPE (f));
-
-  /* Must match the type layout in std::source_location.  */
-  tree ctor = build_constructor_va (s_type, 1, f, impl__);
-
-  TREE_READONLY (ctor) = true;
-  TREE_CONSTANT (ctor) = true;
-  TREE_STATIC (ctor) = true;
-  return ctor;
+  tree p = build_pointer_type (contracts_source_location_impl_type);
+  return build_fold_addr_expr_with_type_loc (loc, impl__, p);
 }
 
 /* Build a layout-compatible internal version of contract_violation type.  */
@@ -2385,7 +2293,7 @@ get_p9600_contract_violation_fields ()
     evaluation_semantic _M_evaluation_semantic;
     detection_mode _M_detection_mode;
     const char* _M_comment;
-    std::source_location _M_source_location;
+    void *_M_src_loc_ptr;
     void *_M_current_except_obj;
     __vendor_ext* _M_ext;
   };
@@ -2396,7 +2304,7 @@ get_p9600_contract_violation_fields ()
 			 uint16_type_node,
 			 uint16_type_node,
 			 const_string_type_node,
-			 get_contracts_source_location_type(),
+			 ptr_type_node,
 			 ptr_type_node,
 			 ptr_type_node
 			};
@@ -2405,7 +2313,7 @@ get_p9600_contract_violation_fields ()
 			 "_M_evaluation_semantic",
 			 "_M_detection_mode",
 			 "_M_comment",
-			 "_M_source_location",
+			 "_M_src_loc_ptr",
 			 "_M_current_except_obj",
 			 "_M_ext",
 			};
@@ -2420,7 +2328,6 @@ get_p9600_contract_violation_fields ()
     }
  return fields;
 }
-
 
 /* Get constract_assertion_kind of the specified contract. Used when building
  P2900R7 contract_violation object.  */
@@ -2492,15 +2399,15 @@ build_contract_violation_p2900 (tree contract, bool is_const)
   /* we hardcode CDM_PREDICATE_FALSE because that's all we support for now */
   uint16_t detection_mode = CDM_PREDICATE_FALSE;
 
-  /* Must match the type layout in get_pseudo_contract_violation_type.  */
+  /* Must match the type layout in builtin_contract_violation_type.  */
   tree ctor = build_constructor_va
-    (get_pseudo_contract_violation_type (), 8,
+    (builtin_contract_violation_type, 8,
      NULL_TREE, build_int_cst (uint16_type_node, version),
      NULL_TREE, build_int_cst (uint16_type_node, assertion_kind),
      NULL_TREE, build_int_cst (uint16_type_node, evaluation_semantic),
      NULL_TREE, build_int_cst (uint16_type_node, detection_mode),
      NULL_TREE, CONTRACT_COMMENT (contract),
-     NULL_TREE, build_contracts_source_location (EXPR_LOCATION (contract)),
+     NULL_TREE, get_contracts_impl_ptr (EXPR_LOCATION (contract)),
      NULL_TREE, build_zero_cst (nullptr_type_node),  // exception
      NULL_TREE, build_zero_cst (nullptr_type_node)); // __vendor_ext
 
@@ -2510,7 +2417,7 @@ build_contract_violation_p2900 (tree contract, bool is_const)
 
   tree viol_ = contracts_tu_local_named_var
     (EXPR_LOCATION (contract), "Lcontract_violation",
-     get_pseudo_contract_violation_type (), /*is_const*/true);
+     builtin_contract_violation_type, /*is_const*/true);
 
   TREE_CONSTANT (viol_) = is_const;
   DECL_INITIAL (viol_) = ctor;
@@ -2559,7 +2466,7 @@ declare_violation_handler_wrappers ()
 
   iloc_sentinel ils (input_location);
   input_location = BUILTINS_LOCATION;
-  tree v_obj_type = get_pseudo_contract_violation_type ();
+  tree v_obj_type = builtin_contract_violation_type;
   v_obj_type = cp_build_qualified_type (v_obj_type, TYPE_QUAL_CONST);
   v_obj_type = cp_build_reference_type (v_obj_type, /*rval*/false);
   tree fn_type = build_function_type_list (void_type_node, v_obj_type,
@@ -2775,6 +2682,37 @@ p2900_check_redecl_contract (tree newdecl, tree olddecl)
 }
 
 /* ======== public API ======= */
+
+tree
+init_builtin_contract_violation_type ()
+{
+  if (builtin_contract_violation_type)
+    return builtin_contract_violation_type;
+
+  tree fields;
+  if (flag_contracts_nonattr)
+    fields = get_p9600_contract_violation_fields ();
+  else
+    fields = get_cxx2a_contract_violation_fields ();
+
+  iloc_sentinel ils (input_location);
+  input_location = BUILTINS_LOCATION;
+  builtin_contract_violation_type = make_class_type (RECORD_TYPE);
+  finish_builtin_struct (builtin_contract_violation_type,
+			 "__builtin_contract_violation_type", fields, NULL_TREE);
+  CLASSTYPE_AS_BASE (builtin_contract_violation_type)
+    = builtin_contract_violation_type;
+  DECL_CONTEXT (TYPE_NAME (builtin_contract_violation_type))
+    = FROB_CONTEXT (global_namespace);
+  TREE_PUBLIC (TYPE_NAME (builtin_contract_violation_type)) = true;
+  CLASSTYPE_LITERAL_P (builtin_contract_violation_type) = true;
+  CLASSTYPE_LAZY_COPY_CTOR (builtin_contract_violation_type) = true;
+  xref_basetypes (builtin_contract_violation_type, /*bases=*/NULL_TREE);
+  builtin_contract_violation_type
+    = cp_build_qualified_type (builtin_contract_violation_type,
+			       TYPE_QUAL_CONST);
+  return builtin_contract_violation_type;
+}
 
 /* Genericize a CONTRACT tree, but do not attach it to the current context,
    the caller is responsible for that.

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -388,6 +388,7 @@ extern tree maybe_contract_wrap_call		(tree, tree);
 extern bool emit_contract_wrapper_func		(bool);
 extern void maybe_emit_violation_handler_wrappers (void);
 
+extern tree init_builtin_contract_violation_type (void);
 extern tree build_contract_check		(tree);
 
 /* Return the first contract in ATTRS, or NULL_TREE if there are none.  */

--- a/gcc/cp/cp-tree.h
+++ b/gcc/cp/cp-tree.h
@@ -235,7 +235,7 @@ enum cp_tree_index
     CPTI_DSO_HANDLE,
     CPTI_DCAST,
 
-    CPTI_PSEUDO_CONTRACT_VIOLATION,
+    CPTI_CONTRACT_VIOLATION_TYPE,
 
     CPTI_MAX
 };
@@ -265,7 +265,7 @@ extern GTY(()) tree cp_global_trees[CPTI_MAX];
 #define current_aggr			cp_global_trees[CPTI_AGGR_TAG]
 /* std::align_val_t */
 #define align_type_node			cp_global_trees[CPTI_ALIGN_TYPE]
-#define pseudo_contract_violation_type	cp_global_trees[CPTI_PSEUDO_CONTRACT_VIOLATION]
+#define builtin_contract_violation_type	cp_global_trees[CPTI_CONTRACT_VIOLATION_TYPE]
 
 /* We cache these tree nodes so as to call get_identifier less frequently.
    For identifiers for functions, including special member functions such

--- a/gcc/cp/decl.cc
+++ b/gcc/cp/decl.cc
@@ -5246,7 +5246,10 @@ cxx_init_decl_processing (void)
     init_exception_processing ();
 
   if (flag_contracts)
-    init_terminate_fn ();
+    {
+      init_terminate_fn ();
+      init_builtin_contract_violation_type ();
+    }
 
   if (modules_p ())
     init_modules (parse_in);

--- a/libstdc++-v3/include/std/contracts
+++ b/libstdc++-v3/include/std/contracts
@@ -116,7 +116,7 @@ namespace contracts
     evaluation_semantic _M_evaluation_semantic;
     detection_mode _M_detection_mode;
     const char* _M_comment;
-    std::source_location _M_source_location;
+    const void* _M_src_loc_ptr;
     void *_M_current_except_obj;
     __vendor_ext* _M_ext;
 
@@ -129,7 +129,7 @@ namespace contracts
        _M_evaluation_semantic(__semantic),
        _M_detection_mode(detection_mode::unspecified),
        _M_comment(__comment),
-       _M_source_location(__location),
+       _M_src_loc_ptr(__location._M_impl),
        _M_current_except_obj (nullptr),
        _M_ext(nullptr)
     {
@@ -172,7 +172,9 @@ namespace contracts
     evaluation_semantic semantic() const noexcept { return _M_evaluation_semantic; }
     detection_mode mode() const noexcept { return _M_detection_mode; }
     const char* comment() const noexcept { return _M_comment; }
-    std::source_location location() const noexcept { return _M_source_location; }
+    std::source_location location() const noexcept {
+      return std::source_location (_M_src_loc_ptr);
+    }
     std::exception_ptr
     evaluation_exception () const noexcept
      {

--- a/libstdc++-v3/include/std/source_location
+++ b/libstdc++-v3/include/std/source_location
@@ -38,6 +38,10 @@
 namespace std
 {
 _GLIBCXX_BEGIN_NAMESPACE_VERSION
+  namespace contracts
+  {
+    class contract_violation;
+  }
 
   /// A class that describes a location in source code.
   struct source_location
@@ -85,6 +89,12 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
   private:
     const __impl* _M_impl = nullptr;
+
+    constexpr source_location (const void *__t)
+      : _M_impl (static_cast <const __impl*>(__t)) {}
+
+    /* To enable use of the source __impl*.  */
+    friend class std::contracts::contract_violation;
   };
 
 _GLIBCXX_END_NAMESPACE_VERSION


### PR DESCRIPTION
The experiment with trying to forward-declare std::source_location conditionally on inclusion of the header did not work - sometimes we need to create it too early and then we get confusion over which version is in force.  So we don't need to do that - a pointer to the data is sufficient.

-----

This does all the work needed to have the builtin type but does not (yet) publish it - since we are still figuring out the details of the ABI - however,

In this version, we no longer try to declare or build a std::source_location since this creates quite some difficulty with needing the declaration whether <source_location> is included or not.

Instead, we save a type-erased pointer to the implementation data. Since clang and GCC actually use the same layout here, there is a move to add this to the Itanium spec at that point we will be able to use some __cxa_xxxxx_t * as the pointer type.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
