### PR TITLE
c++, contracts: Allow for dynamic contract stmt content.

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -2333,8 +2333,18 @@ get_p9600_contract_violation_fields ()
  P2900R7 contract_violation object.  */
 
 static int
-get_contract_assertion_kind(tree contract)
+get_contract_assertion_kind (tree contract)
 {
+  gcc_checking_assert (flag_contracts_nonattr);
+  if (CONTRACT_ASSERTION_KIND (contract))
+    {
+      tree s = CONTRACT_ASSERTION_KIND (contract);
+      tree i = (TREE_CODE (s) == INTEGER_CST) ? s
+					      : DECL_INITIAL (STRIP_NOPS (s));
+      gcc_checking_assert (!type_dependent_expression_p (s) && i);
+      return (uint16_t) tree_to_uhwi (i);
+    }
+
   switch (TREE_CODE (contract))
   {
     case ASSERTION_STMT:	return CAK_ASSERT;
@@ -2353,6 +2363,15 @@ static uint16_t
 get_evaluation_semantic (tree contract)
 {
   gcc_checking_assert (flag_contracts_nonattr);
+  if (CONTRACT_EVALUATION_SEMANTIC (contract))
+    {
+      tree s = CONTRACT_EVALUATION_SEMANTIC (contract);
+      tree i = (TREE_CODE (s) == INTEGER_CST) ? s
+					      : DECL_INITIAL (STRIP_NOPS (s));
+      gcc_checking_assert (!type_dependent_expression_p (s) && i);
+      return (uint16_t) tree_to_uhwi (i);
+    }
+
   /* Temporary; pick up the semantic from the bitfield and translate to the
      P2900 version.  */
   contract_semantic semantic = get_contract_semantic (contract);
@@ -2389,32 +2408,81 @@ emit_builtin_observable ()
 
 /* Build a p2900 contract_violation layout compatible object. */
 
-static tree
-build_contract_violation_p2900 (tree contract, bool is_const)
-{
-  uint16_t version = 1;
-  uint16_t assertion_kind = get_contract_assertion_kind (contract);
-  uint16_t evaluation_semantic = get_evaluation_semantic (contract);
+/* Constructor - possibly not constant. */
 
-  /* we hardcode CDM_PREDICATE_FALSE because that's all we support for now */
+static tree
+build_contract_violation_p2900_ctor (tree contract)
+{
+  bool can_be_const = true;
+  uint16_t version = 1;
+  /* Default CDM_PREDICATE_FALSE. */
   uint16_t detection_mode = CDM_PREDICATE_FALSE;
 
+  tree assertion_kind = CONTRACT_ASSERTION_KIND (contract);
+  if (!assertion_kind || really_constant_p (assertion_kind))
+    {
+      uint16_t kind = get_contract_assertion_kind (contract);
+      assertion_kind = build_int_cst (uint16_type_node, kind);
+      // D3290R3 makes detection mode unspecified.
+      if (kind == CAK_MANUAL || kind == CAK_CASSERT)
+	detection_mode = CDM_UNSPECIFIED;
+    }
+  else
+    can_be_const = false;
+
+  tree eval_semantic = CONTRACT_EVALUATION_SEMANTIC (contract);
+  if (!eval_semantic || really_constant_p (eval_semantic))
+    {
+      uint16_t semantic = get_evaluation_semantic (contract);
+      eval_semantic = build_int_cst (uint16_type_node, semantic);
+    }
+  else
+    can_be_const = false;
+
+  tree comment = CONTRACT_COMMENT (contract);
+  if (comment && !really_constant_p (comment))
+    can_be_const = false;
+
+  tree std_source_loc_impl = CONTRACT_STD_SOURCE_LOC (contract);
+  if (std_source_loc_impl)
+    {
+      std_source_loc_impl = convert_from_reference (std_source_loc_impl);
+      if (!really_constant_p (std_source_loc_impl))
+	can_be_const = false;
+    }
+  else
+    std_source_loc_impl = get_contracts_impl_ptr (EXPR_LOCATION (contract));
+
   /* Must match the type layout in builtin_contract_violation_type.  */
+  tree f0 = next_aggregate_field (TYPE_FIELDS (builtin_contract_violation_type));
+  tree f1 = next_aggregate_field (DECL_CHAIN (f0));
+  tree f2 = next_aggregate_field (DECL_CHAIN (f1));
+  tree f3 = next_aggregate_field (DECL_CHAIN (f2));
+  tree f4 = next_aggregate_field (DECL_CHAIN (f3));
+  tree f5 = next_aggregate_field (DECL_CHAIN (f4));
+  tree f6 = next_aggregate_field (DECL_CHAIN (f5));
+  tree f7 = next_aggregate_field (DECL_CHAIN (f6));
   tree ctor = build_constructor_va
     (builtin_contract_violation_type, 8,
-     NULL_TREE, build_int_cst (uint16_type_node, version),
-     NULL_TREE, build_int_cst (uint16_type_node, assertion_kind),
-     NULL_TREE, build_int_cst (uint16_type_node, evaluation_semantic),
-     NULL_TREE, build_int_cst (uint16_type_node, detection_mode),
-     NULL_TREE, CONTRACT_COMMENT (contract),
-     NULL_TREE, get_contracts_impl_ptr (EXPR_LOCATION (contract)),
-     NULL_TREE, build_zero_cst (nullptr_type_node),  // exception
-     NULL_TREE, build_zero_cst (nullptr_type_node)); // __vendor_ext
+     f0, build_int_cst (uint16_type_node, version),
+     f1, assertion_kind,
+     f2, eval_semantic,
+     f3, build_int_cst (uint16_type_node, detection_mode),
+     f4, comment,
+     f5, std_source_loc_impl,
+     f6, build_zero_cst (nullptr_type_node),  // exception
+     f7, build_zero_cst (nullptr_type_node));  // __vendor_ext
 
   TREE_READONLY (ctor) = true;
-  TREE_CONSTANT (ctor) = true;
-  TREE_STATIC (ctor) = true;
+  if (can_be_const)
+    TREE_CONSTANT (ctor) = true;
 
+  return ctor;
+}
+
+static tree
+build_contract_violation_p2900_constant (tree ctor, tree contract, bool is_const)
+{
   tree viol_ = contracts_tu_local_named_var
     (EXPR_LOCATION (contract), "Lcontract_violation",
      builtin_contract_violation_type, /*is_const*/true);
@@ -2424,6 +2492,28 @@ build_contract_violation_p2900 (tree contract, bool is_const)
   varpool_node::finalize_decl (viol_);
 
   return viol_;
+}
+
+static tree
+build_contract_violation_p2900_var (tree ctor, tree contract)
+{
+  location_t loc = EXPR_LOCATION (contract);
+  tree a_type
+    = strip_top_quals (non_reference (builtin_contract_violation_type));
+  tree viol_ = build_decl (loc, VAR_DECL, NULL_TREE, a_type);
+  DECL_SOURCE_LOCATION (viol_) = loc;
+  DECL_CONTEXT (viol_) = current_function_decl;
+  DECL_ARTIFICIAL (viol_) = true;
+  layout_decl (viol_, 0);
+  DECL_INITIAL (viol_) = ctor;
+  return viol_;
+}
+
+static tree
+build_contract_violation_p2900 (tree contract, bool is_const)
+{
+  tree ctor = build_contract_violation_p2900_ctor (contract);
+  return build_contract_violation_p2900_constant (ctor, contract, is_const);
 }
 
 /* Shared code between TU-local wrappers for the violation handler.  */
@@ -2515,7 +2605,7 @@ build_contract_check_p2900 (tree contract)
 			   && !expr_noexcept_p (condition, tf_none);
 
   /* Build a read-only violation object, with the contract settings.  */
-  tree violation = build_contract_violation (contract, /*is_const*/true);
+  //tree violation = build_contract_violation (contract, /*is_const*/true);
   /* Build a statement expression to hold a contract check, with the check
      potentially wrapped in a try-catch expr.  */
   tree cc_bind = build3 (BIND_EXPR, void_type_node, NULL, NULL, NULL);
@@ -2526,6 +2616,18 @@ build_contract_check_p2900 (tree contract)
     emit_builtin_observable ();
   tree cond = build_x_unary_op (loc, TRUTH_NOT_EXPR, condition, NULL_TREE,
 				tf_warning_or_error);
+  tree ctor = build_contract_violation_p2900_ctor (contract);
+  tree violation = NULL_TREE;
+  bool viol_is_var = false;
+  if (TREE_CONSTANT (ctor))
+    violation = build_contract_violation_p2900_constant (ctor, contract, /*is_const*/true);
+  else
+    {
+      violation = build_contract_violation_p2900_var (ctor, contract);
+      add_decl_expr (violation);
+      BIND_EXPR_VARS (cc_bind) = violation;
+      viol_is_var = true;
+    }
   /* So now do we need a try-catch?  */
   if (check_might_throw)
     {
@@ -2536,6 +2638,8 @@ build_contract_check_p2900 (tree contract)
       DECL_CONTEXT (check_failed) = current_function_decl;
       layout_decl (check_failed, 0);
       add_decl_expr (check_failed);
+      DECL_CHAIN (check_failed) = BIND_EXPR_VARS (cc_bind);
+      BIND_EXPR_VARS (cc_bind) = check_failed;
       /* This will let us check if we had an exception.  */
       tree no_excp_ = build_decl (loc, VAR_DECL, NULL, boolean_type_node);
       DECL_ARTIFICIAL (no_excp_) = true;
@@ -2544,8 +2648,8 @@ build_contract_check_p2900 (tree contract)
       DECL_INITIAL (no_excp_) = boolean_true_node;
       layout_decl (no_excp_, 0);
       add_decl_expr (no_excp_);
-      DECL_CHAIN (check_failed) = no_excp_;
-      BIND_EXPR_VARS (cc_bind) = check_failed;
+      DECL_CHAIN (no_excp_) = BIND_EXPR_VARS (cc_bind);
+      BIND_EXPR_VARS (cc_bind) = no_excp_;
 
       tree check_try = begin_try_block ();
       finish_expr_stmt (cp_build_init_expr (check_failed, cond));
@@ -2555,12 +2659,34 @@ build_contract_check_p2900 (tree contract)
       tree e = cp_build_modify_expr (loc, no_excp_, NOP_EXPR, boolean_false_node,
 				     tf_warning_or_error);
       finish_expr_stmt (e);
-      finish_expr_stmt (build_call_n (__tu_has_violation_exception, 2,
-				      build_address (violation),
-				      build_int_cst (uint16_type_node, semantic)));
+      tree s_const = build_int_cst (uint16_type_node, semantic);
+      if (viol_is_var)
+	{
+	  /* We can update the detection mode here.  */
+	  tree memb
+	    = lookup_member (builtin_contract_violation_type,
+			     get_identifier ("_M_detection_mode"),
+			     1, 0, tf_warning_or_error);
+	  tree r
+	    = build_class_member_access_expr (violation, memb, NULL_TREE, false,
+					      tf_warning_or_error);
+	  r = cp_build_modify_expr (loc, r, NOP_EXPR,
+				build_int_cst (uint16_type_node, (uint16_t)CDM_EVAL_EXCEPTION),
+				tf_warning_or_error);
+	  finish_expr_stmt (r);
+	  finish_expr_stmt (build_call_n (__tu_has_violation, 2,
+					  build_address (violation),
+					  s_const));
+	}
+      else
+	/* We need to make a copy of the violation object to update.  */
+	finish_expr_stmt (build_call_n (__tu_has_violation_exception, 2,
+					build_address (violation),
+					s_const));
       finish_handler (handler);
       finish_handler_sequence (check_try);
       cond = build2 (TRUTH_ANDIF_EXPR, boolean_type_node, check_failed, no_excp_);
+      BIND_EXPR_VARS (cc_bind) = nreverse (BIND_EXPR_VARS (cc_bind));
     }
 
   tree do_check = begin_if_stmt ();
@@ -3838,12 +3964,16 @@ grok_contract (tree attribute, tree mode, tree result, cp_expr condition,
      the contract is deferred, result an plain identifier, not a result
      variable.  */
   tree contract;
-  tree type = void_type_node;
   if (code != POSTCONDITION_STMT)
-    contract = build3_loc (loc, code, type, mode, NULL_TREE, NULL_TREE);
+    contract = build5_loc (loc, code, void_type_node, mode,
+			   NULL_TREE, NULL_TREE, NULL_TREE, NULL_TREE);
   else
-    contract = build4_loc (loc, code, type, mode, NULL_TREE, NULL_TREE,
-			   result);
+    {
+      contract = build_nt (code, mode, NULL_TREE, NULL_TREE,
+			   NULL_TREE, NULL_TREE, result);
+      TREE_TYPE (contract) = void_type_node;
+      SET_EXPR_LOCATION (contract, loc);
+    }
 
   /* Determine the evaluation semantic:
      First, apply the c++2a rules

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -252,6 +252,14 @@ enum contract_inheritance
   CONTRACTS_ON_VIRTUALS_P3653 = 2,
 };
 
+/* P2900 meanings.  */
+/* evaluation_semantic */
+#define CONTRACT_EVALUATION_SEMANTIC(NODE) \
+  (TREE_OPERAND (CONTRACT_CHECK (NODE), 0))
+
+#define CONTRACT_ASSERTION_KIND(NODE) \
+  (TREE_OPERAND (CONTRACT_CHECK (NODE), 1))
+
 /* =========================== common ============================  */
 
 #define CONTRACT_CHECK(NODE) \
@@ -304,7 +312,7 @@ enum contract_inheritance
 
 /* The parsed condition of the contract.  */
 #define CONTRACT_CONDITION(NODE) \
-  (TREE_OPERAND (CONTRACT_CHECK (NODE), 1))
+  (TREE_OPERAND (CONTRACT_CHECK (NODE), 2))
 
 /* True iff the condition of the contract NODE is not yet parsed.  */
 #define CONTRACT_CONDITION_DEFERRED_P(NODE) \
@@ -312,12 +320,16 @@ enum contract_inheritance
 
 /* The raw comment of the contract.  */
 #define CONTRACT_COMMENT(NODE) \
-  (TREE_OPERAND (CONTRACT_CHECK (NODE), 2))
+  (TREE_OPERAND (CONTRACT_CHECK (NODE), 3))
+
+/* A std::source_location, if provided.  */
+#define CONTRACT_STD_SOURCE_LOC(NODE) \
+  (TREE_OPERAND (CONTRACT_CHECK (NODE), 4))
 
 /* The VAR_DECL of a postcondition result. For deferred contracts, this
    is an IDENTIFIER.  */
 #define POSTCONDITION_IDENTIFIER(NODE) \
-  (TREE_OPERAND (POSTCONDITION_STMT_CHECK (NODE), 3))
+  (TREE_OPERAND (POSTCONDITION_STMT_CHECK (NODE), 5))
 
 /* For a FUNCTION_DECL of a guarded function, this holds the function decl
    where pre contract checks are emitted.  */

--- a/gcc/cp/cp-tree.def
+++ b/gcc/cp/cp-tree.def
@@ -576,9 +576,9 @@ DEFTREECODE (CO_RETURN_EXPR, "co_return", tcc_statement, 2)
    operand to store the optional name for the result value.
 
    CONTRACT_SEMANTIC has the computed behavior of the contract.  */
-DEFTREECODE (ASSERTION_STMT, "assertion_stmt", tcc_statement, 3)
-DEFTREECODE (PRECONDITION_STMT, "precondition_stmt", tcc_statement, 3)
-DEFTREECODE (POSTCONDITION_STMT, "postcondition_stmt", tcc_statement, 4)
+DEFTREECODE (ASSERTION_STMT, "assertion_stmt", tcc_statement, 5)
+DEFTREECODE (PRECONDITION_STMT, "precondition_stmt", tcc_statement, 5)
+DEFTREECODE (POSTCONDITION_STMT, "postcondition_stmt", tcc_statement, 6)
 
 /* A reference to a translation-unit local entity.
 

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -12175,12 +12175,18 @@ tsubst_contract (tree decl, tree t, tree args, tsubst_flags_t complain,
   cp_expr new_condition (cond_t, cond_l);
   CONTRACT_CONDITION (r) = finish_contract_condition (new_condition);
 
+  if (flag_contracts_nonattr)
+    {
+  /* The semantic, if present.  */
+  CONTRACT_EVALUATION_SEMANTIC (r)
+    = tsubst_expr (CONTRACT_EVALUATION_SEMANTIC (r), args, complain, in_decl);
+
+  /* The assertion kind, if present.  */
+  CONTRACT_ASSERTION_KIND (r)
+    = tsubst_expr (CONTRACT_ASSERTION_KIND (r), args, complain, in_decl);
+    }
+
   /* And the comment.  */
-  /* TODO : this does not do anything at the moment. The CONTRACT_COMMENT is
-     (currently) a string literal, built from the string of the contract.
-     There is nothing to substitute. If we wanted to rebuild the
-     CONTRACT_COMMENT from the substituted contract tree, we would need to
-     modify how a CONTRACT_COMMENT is built.  */
   CONTRACT_COMMENT (r)
       = tsubst_expr (CONTRACT_COMMENT (r), args, complain, in_decl);
 


### PR DESCRIPTION
More prep work, this makes it possible to have semantic values > 7 but does not yet implement that part.

---

This allows us to put values for semantic and assertion type that will not fit into the LANG_ bits

This is intended to allow the library to make use of compiler-side logic to implement changes in semantic handling, rather than duplicating this.

