### PR TITLE
Contracts nonattr use semantic field

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1948,6 +1948,8 @@ fcontract-semantic=
 C++ Joined RejectNegative
 -fcontract-semantic=<level>:<semantic>	Specify the concrete semantics for level.
 
+; Keep these in step with the values in cp/contracts.h
+
 Enum
 Name(p2900_semantic) Type(int)  UnknownError(unrecognized contract evaluation semantic %qs)
 
@@ -1958,10 +1960,10 @@ EnumValue
 Enum(p2900_semantic) String(enforce) Value(3)
 
 EnumValue
-Enum(p2900_semantic) String(observe) Value(4)
+Enum(p2900_semantic) String(observe) Value(2)
 
 EnumValue
-Enum(p2900_semantic) String(quick_enforce) Value(5)
+Enum(p2900_semantic) String(quick_enforce) Value(4)
 
 EnumValue
 Enum(p2900_semantic) String(noexcept_enforce) Value(6)
@@ -1970,7 +1972,7 @@ EnumValue
 Enum(p2900_semantic) String(noexcept_observe) Value(7)
 
 fcontract-evaluation-semantic=
-C++ Joined RejectNegative Enum(p2900_semantic) Var(flag_contract_evaluation_semantic) Init (3)
+C++ Joined RejectNegative Enum(p2900_semantic) Var(flag_contract_evaluation_semantic) Init(3)
 -fcontract-evaluation-semantic=[ignore|observe|enforce|quick_enforce|noexcept_enforce|noexcept_observe]	Select the contract evaluation semantic (defaults to enforce).
 
 fcontract-checks-outlined
@@ -1998,7 +2000,7 @@ EnumValue
 Enum(client_contract_check) String(all) Value(2)
 
 fcontracts-nonattr-client-check=
-C++ Joined RejectNegative Enum(client_contract_check) Var(flag_contract_nonattr_client_check) Init (0)
+C++ Joined RejectNegative Enum(client_contract_check) Var(flag_contract_nonattr_client_check) Init(0)
 -fcontracts-nonattr-client-check=[none|pre|all] Select which contracts will be checked on the client side for non virtual functions
 
 fcontracts-nonattr-definition-check=

--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -1965,11 +1965,13 @@ Enum(p2900_semantic) String(observe) Value(2)
 EnumValue
 Enum(p2900_semantic) String(quick_enforce) Value(4)
 
-EnumValue
-Enum(p2900_semantic) String(noexcept_enforce) Value(6)
+; Implementation-defined semantics have values >= 1000.
 
 EnumValue
-Enum(p2900_semantic) String(noexcept_observe) Value(7)
+Enum(p2900_semantic) String(noexcept_enforce) Value(1001)
+
+EnumValue
+Enum(p2900_semantic) String(noexcept_observe) Value(1002)
 
 fcontract-evaluation-semantic=
 C++ Joined RejectNegative Enum(p2900_semantic) Var(flag_contract_evaluation_semantic) Init(3)

--- a/gcc/cp/constexpr.cc
+++ b/gcc/cp/constexpr.cc
@@ -12532,7 +12532,7 @@ potential_constant_expression_1 (tree t, bool want_rval, bool strict, bool now,
     case ASSERTION_STMT:
     case PRECONDITION_STMT:
     case POSTCONDITION_STMT:
-      if (!checked_contract_p (get_contract_semantic (t)))
+      if (!contract_evaluated_p (t))
 	return true;
       return RECUR (CONTRACT_CONDITION (t), rval);
 

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -567,7 +567,10 @@ build_contract_condition_function (tree fndecl, bool pre)
 static bool
 contract_active_p (tree contract)
 {
-  return get_contract_semantic (contract) != CCS_IGNORE;
+  if (flag_contracts_nonattr)
+    return get_evaluation_semantic (contract) != CES_IGNORE;
+  else
+    return get_contract_semantic (contract) != CCS_IGNORE;
 }
 
 /* True if FNDECL has any checked or assumed contracts whose TREE_CODE is
@@ -888,8 +891,15 @@ emit_contract_statement (tree contract)
 {
   /* Only add valid contracts.  */
   if (contract == error_mark_node
-      || CONTRACT_CONDITION (contract) == error_mark_node
-      || get_contract_semantic (contract) == CCS_INVALID)
+      || CONTRACT_CONDITION (contract) == error_mark_node)
+    return false;
+
+  if (flag_contracts_nonattr
+      && get_evaluation_semantic (contract) == CES_INVALID)
+    return false;
+
+  if (!flag_contracts_nonattr
+      && get_contract_semantic (contract) == CCS_INVALID)
     return false;
 
   add_stmt (contract);
@@ -2345,8 +2355,8 @@ get_contract_assertion_kind (tree contract)
 
 /* Get contract_evaluation_semantic of the specified contract.  */
 
-static uint16_t
-get_evaluation_semantic (tree contract)
+contract_evaluation_semantic
+get_evaluation_semantic (const_tree contract)
 {
   gcc_checking_assert (flag_contracts_nonattr);
   if (CONTRACT_EVALUATION_SEMANTIC (contract))
@@ -2355,29 +2365,11 @@ get_evaluation_semantic (tree contract)
       tree i = (TREE_CODE (s) == INTEGER_CST) ? s
 					      : DECL_INITIAL (STRIP_NOPS (s));
       gcc_checking_assert (!type_dependent_expression_p (s) && i);
-      return (uint16_t) tree_to_uhwi (i);
+      return (contract_evaluation_semantic) tree_to_uhwi (i);
     }
 
-  /* Temporary; pick up the semantic from the bitfield and translate to the
-     P2900 version.  */
-  contract_semantic semantic = get_contract_semantic (contract);
-  switch (semantic)
-    {
-      default:
-	gcc_unreachable ();
-      case CCS_IGNORE:
-	return CES_IGNORE;
-      case CCS_OBSERVE:
-	return CES_OBSERVE;
-      case CCS_ENFORCE:
-	return CES_ENFORCE;
-      case CCS_QUICK:
-	return CES_QUICK;
-      case CCS_NOEXCEPT_ENFORCE:
-	return CES_NOEXCEPT_ENFORCE;
-      case CCS_NOEXCEPT_OBSERVE:
-	return CES_NOEXCEPT_OBSERVE;
-    }
+  gcc_checking_assert (0 && "we should not get here");
+  return CES_INVALID;
 }
 
 /* Insert a BUILT_IN_OBSERVABLE epoch marker.  */
@@ -2417,12 +2409,8 @@ build_contract_violation_p2900_ctor (tree contract)
     can_be_const = false;
 
   tree eval_semantic = CONTRACT_EVALUATION_SEMANTIC (contract);
-  if (!eval_semantic || really_constant_p (eval_semantic))
-    {
-      uint16_t semantic = get_evaluation_semantic (contract);
-      eval_semantic = build_int_cst (uint16_type_node, semantic);
-    }
-  else
+  gcc_checking_assert (eval_semantic && "We should have set this.");
+  if (!really_constant_p (eval_semantic))
     can_be_const = false;
 
   tree comment = CONTRACT_COMMENT (contract);
@@ -2555,7 +2543,7 @@ declare_violation_handler_wrappers ()
 static tree
 build_contract_check_p2900 (tree contract)
 {
-  uint16_t semantic = get_evaluation_semantic (contract);
+  contract_evaluation_semantic semantic = get_evaluation_semantic (contract);
   if (semantic == CES_INVALID)
     return NULL_TREE;
 
@@ -2589,9 +2577,8 @@ build_contract_check_p2900 (tree contract)
      noexcept_observe.  */
   if (flag_contracts_disable_predicate_exception_translation)
     {
-      uint16_t eval_semantic = get_evaluation_semantic (contract);
-      if (eval_semantic != CES_NOEXCEPT_ENFORCE
-	  && eval_semantic != CES_NOEXCEPT_OBSERVE)
+      if (semantic != CES_NOEXCEPT_ENFORCE
+	  && semantic != CES_NOEXCEPT_OBSERVE)
 	predicate_needs_catch = false;
       else
 	warning_at (loc, 1,
@@ -3971,15 +3958,22 @@ grok_contract (tree attribute, tree mode, tree result, cp_expr condition,
       SET_EXPR_LOCATION (contract, loc);
     }
 
-  /* Determine the evaluation semantic:
-     First, apply the c++2a rules
-     FIXME: this is a convenience to avoid updating many tests.  */
-  contract_semantic semantic = compute_concrete_semantic (contract);
-  if (flag_contracts_nonattr
-      && OPTION_SET_P (flag_contract_evaluation_semantic))
-    semantic
-      = static_cast<contract_semantic>(flag_contract_evaluation_semantic);
-  set_contract_semantic (contract, semantic);
+  /* Determine the evaluation semantic.  */
+  if (flag_contracts_nonattr)
+    {
+      /* This is now an override, so that if not set we will get the default
+	 (currently enforce).  */
+      contract_evaluation_semantic ev_semantic
+	= static_cast<contract_evaluation_semantic>
+		     (flag_contract_evaluation_semantic);
+      CONTRACT_EVALUATION_SEMANTIC (contract)
+	= build_int_cst (uint16_type_node, (uint16_t) ev_semantic);
+    }
+  else
+    {
+      contract_semantic semantic = compute_concrete_semantic (contract);
+      set_contract_semantic (contract, semantic);
+    }
 
   /* If the contract is deferred, don't do anything with the condition.  */
   if (TREE_CODE (condition) == DEFERRED_PARSE)

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -225,10 +225,9 @@ enum contract_evaluation_semantic : uint16_t {
   CES_ENFORCE = 3,
   CES_QUICK = 4,
 
-  // These should start at 1000
-  CES_NOEXCEPT_ENFORCE = 5,
-  CES_NOEXCEPT_OBSERVE = 6,
-  CES_FORCE_QUICK = 7,
+  /* Implementation-defined.  */
+  CES_NOEXCEPT_ENFORCE = 1001,
+  CES_NOEXCEPT_OBSERVE = 1002,
 };
 
 enum detection_mode : uint16_t {

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -362,6 +362,7 @@ extern void set_contract_attributes 		(tree, tree);
 extern bool all_attributes_are_contracts_p	(tree);
 extern tree finish_contract_attribute		(tree, tree);
 extern bool diagnose_misapplied_contracts	(tree);
+extern contract_evaluation_semantic get_evaluation_semantic (const_tree);
 
 extern tree make_postcondition_variable		(cp_expr);
 extern tree make_postcondition_variable		(cp_expr, tree);
@@ -524,6 +525,8 @@ parm_used_in_post_p (const_tree decl)
 inline bool
 contract_ignored_p (const_tree contract)
 {
+  if (flag_contracts_nonattr)
+    return (get_evaluation_semantic (contract) <= CES_IGNORE);
   return (get_contract_semantic (contract) <= CCS_IGNORE);
 }
 
@@ -532,6 +535,8 @@ contract_ignored_p (const_tree contract)
 inline bool
 contract_evaluated_p (const_tree contract)
 {
+  if (flag_contracts_nonattr)
+    return (get_evaluation_semantic (contract) >= CES_OBSERVE);
   return (get_contract_semantic (contract) >= CCS_NEVER);
 }
 #endif /* ! GCC_CP_CONTRACT_H */

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception-passthrough3.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception-passthrough3.C
@@ -18,4 +18,4 @@ int main(int, char**)
 }
 
 // { dg-output "contract violation in function void f.. at .*: check.15..*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: pre, semantic: unknown: 6, mode: evaluation_exception: threw an instance of .int., terminating: no.*(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: unknown: 1002, mode: evaluation_exception: threw an instance of .int., terminating: no.*(\n|\r\n|\r)" }

--- a/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception-passthrough4.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/contracts-exception-passthrough4.C
@@ -28,4 +28,4 @@ int main(int, char**)
 }
 
 // { dg-output "contract violation in function void f.. at .*: check.15..*(\n|\r\n|\r)" }
-// { dg-output ".assertion_kind: pre, semantic: unknown: 5, mode: evaluation_exception: threw an instance of .int., terminating: no.*(\n|\r\n|\r)" }
+// { dg-output ".assertion_kind: pre, semantic: unknown: 1001, mode: evaluation_exception: threw an instance of .int., terminating: no.*(\n|\r\n|\r)" }

--- a/libstdc++-v3/include/std/contracts
+++ b/libstdc++-v3/include/std/contracts
@@ -90,17 +90,14 @@ namespace contracts
     enforce = 3,
     quick_enforce = 4,
 
-    /* FIXME: Implementation−defined values should have a minimum value of 1000
-      but we cannot [currently] accommodate > 7.
-      Experimental only (no paper).  */
-    noexcept_enforce = 5,
-    noexcept_observe = 6,
-    force_quick = 7,
+    /* Implementation−defined values.
+       Experimental only (no paper).  */
+    noexcept_enforce = 1001,
+    noexcept_observe = 1002,
   };
 
   enum class detection_mode : uint16_t {
-    // From D3290R3
-    unspecified = 0,
+    unspecified = 0, // From D3290R3
     predicate_false = 1,
     evaluation_exception = 2,
 


### PR DESCRIPTION
Two steps 
 - one actually use the semantic slot we provided in the contract tree (for P2900 only)
 - two use values for the noexcept-xxxx semantics that meet recommended practice.
