### PR TITLE
c++, contracts: Add a noipa wrapper around terminate calls.

### DIFF
--- a/gcc/c-family/c.opt
+++ b/gcc/c-family/c.opt
@@ -2029,6 +2029,11 @@ Wsuggest-explicit-contract
 C++ ObjC++ Var(suggest_explicit_contract) Warning
 Warn about functions with implicitly inherited contracts.
 
+fcontracts-conservative-ipa
+C++ ObjC++ Var(flag_contracts_conservative_ipa) Init(1)
+-fcontracts-conservative-ipa	Do not allow certain optimisations between
+functions in contract assertions.
+
 fcoroutines
 C++ LTO Var(flag_coroutines)
 Enable C++ coroutines (experimental).

--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -477,6 +477,7 @@ build_contract_condition_function (tree fndecl, bool pre)
       = tree_cons (get_identifier ("optimize"),
 		   build_tree_list (NULL_TREE, build_string (3, "-O0")),
 		   NULL_TREE);
+
   /* Now parse and add any internal representation of these attrs to the
      decl.  */
   if (DECL_ATTRIBUTES (fn))
@@ -2568,6 +2569,63 @@ declare_violation_handler_wrappers ()
 					     uint16_type_node);
 }
 
+static GTY(()) tree __tu_terminate_wrapper = NULL_TREE;
+
+/* Define the noipa wrapper around the call to std::terminate */
+
+static void build_terminate_wrapper()
+{
+  start_preparsed_function (__tu_terminate_wrapper,
+			    DECL_ATTRIBUTES(__tu_terminate_wrapper),
+			    SF_DEFAULT | SF_PRE_PARSED);
+  tree body = begin_function_body ();
+  tree compound_stmt = begin_compound_stmt (BCS_FN_BODY);
+  finish_expr_stmt (build_call_a (terminate_fn, 0, nullptr));
+  finish_return_stmt (NULL_TREE);
+  finish_compound_stmt (compound_stmt);
+  finish_function_body (body);
+  __tu_terminate_wrapper = finish_function (false);
+  expand_or_defer_fn (__tu_terminate_wrapper);
+}
+
+/* Get the decl for the noipa wrapper around the call to std::terminate */
+
+static tree
+get_terminate_wrapper ()
+{
+  if (__tu_terminate_wrapper)
+    return __tu_terminate_wrapper;
+
+  iloc_sentinel ils (input_location);
+  input_location = BUILTINS_LOCATION;
+
+  tree fn_type = build_function_type_list (void_type_node, NULL_TREE);
+  if (!TREE_NOTHROW (terminate_fn))
+    fn_type = build_exception_variant (fn_type, noexcept_true_spec);
+  tree fn_name = get_identifier ("__tu_terminate_wrapper");
+
+  __tu_terminate_wrapper
+    = build_lang_decl_loc (input_location, FUNCTION_DECL, fn_name, fn_type);
+  DECL_CONTEXT (__tu_terminate_wrapper) = FROB_CONTEXT(global_namespace);
+  DECL_ARTIFICIAL (__tu_terminate_wrapper) = true;
+  DECL_INITIAL (__tu_terminate_wrapper) = error_mark_node;
+  /* Let the start function code fill in the result decl.  */
+  DECL_RESULT (__tu_terminate_wrapper) = NULL_TREE;
+
+  /* Make this function internal.  */
+  TREE_PUBLIC (__tu_terminate_wrapper) = false;
+  DECL_EXTERNAL (__tu_terminate_wrapper) = false;
+  DECL_WEAK (__tu_terminate_wrapper) = false;
+
+  DECL_ATTRIBUTES (__tu_terminate_wrapper)
+    = tree_cons (get_identifier ("noipa"), NULL, NULL_TREE);
+  cplus_decl_attributes (&__tu_terminate_wrapper,
+			 DECL_ATTRIBUTES (__tu_terminate_wrapper), 0);
+  build_terminate_wrapper();
+
+  return __tu_terminate_wrapper;
+}
+
 /* Expand a p2900 CONTRACT tree.  This is called during genericization.  */
 
 static tree
@@ -3673,6 +3731,10 @@ maybe_emit_violation_handler_wrappers ()
   if (!__tu_has_violation && !__tu_has_violation_exception)
     return;
 
+  tree terminate_wrapper = terminate_fn;
+  if (flag_contracts_conservative_ipa)
+    terminate_wrapper = get_terminate_wrapper ();
+
   /* __tu_has_violation */
   start_preparsed_function (__tu_has_violation, NULL_TREE,
 			    SF_DEFAULT | SF_PRE_PARSED);
@@ -3718,7 +3780,7 @@ maybe_emit_violation_handler_wrappers ()
 
   finish_if_stmt (if_quick);
   /* else terminate.  */
-  finish_expr_stmt (build_call_a (terminate_fn, 0, nullptr));
+  finish_expr_stmt (build_call_a (terminate_wrapper, 0, nullptr));
   finish_compound_stmt (compound_stmt);
   finish_function_body (body);
   __tu_has_violation = finish_function (false);

--- a/gcc/testsuite/g++.dg/contracts/cpp26/noipa.C
+++ b/gcc/testsuite/g++.dg/contracts/cpp26/noipa.C
@@ -1,0 +1,22 @@
+// check that we do not optimise based on contract_asssert
+// { dg-additional-options "-O3 -fcontracts -fcontracts-nonattr -fcontract-evaluation-semantic=quick_enforce -fdump-tree-optimized " }
+// { dg-do compile { target c++23 } }
+
+[[gnu::used, gnu::noinline]]
+inline int* f(int *y) {
+  contract_assert(y != nullptr);
+  return y;
+}
+
+
+int foo(int *x) {
+    if (f(x) == nullptr)
+    {
+        return 0;
+    }
+    return *x;
+}
+
+// Check that the if condition in foo isn't optimised away, we should see the
+// nullptr check twice.
+// { dg-final { scan-tree-dump-times {if \([^=]+== 0B\)} 2 "optimized" } }


### PR DESCRIPTION
this is a patch from @NinaRanns (with some small tweaks by me to add the control flag as requested)
`-f{no-}contracts-conservative-ipa` ... the implementation is not (yet) subtle - just applied as noted in a conservative manner.  We will refine this as/when the upstream issue is resolved.
